### PR TITLE
Harden web-widget SVG rendering for kid-safe output

### DIFF
--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -1,5 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { sanitizeSvgOutline } from '../utils/svgSanitizer.js';
 
 type OutlineStyle = 'animals' | 'space' | 'underwater' | undefined;
 
@@ -138,7 +139,13 @@ export const ColoringBook = () => {
         setOutline(undefined);
         setError(result.message ?? 'KidBot paused this outline request.');
       } else {
-        setOutline(result.svg);
+        const sanitized = sanitizeSvgOutline(result.svg);
+        if (!sanitized) {
+          setOutline(undefined);
+          setError('KidBot removed an unsafe outline. Try a different scene.');
+        } else {
+          setOutline(sanitized);
+        }
       }
       setStrokes([]);
     } catch (err) {

--- a/apps/web-widget/src/utils/svgSanitizer.test.ts
+++ b/apps/web-widget/src/utils/svgSanitizer.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSvgOutline } from './svgSanitizer.js';
+
+describe('sanitizeSvgOutline', () => {
+  it('keeps benign kid-safe SVG outlines', () => {
+    const safeSvg =
+      '<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><g stroke="#111827" fill="none"><circle cx="256" cy="256" r="128" /><path d="M128 300 Q256 420 384 300" /></g></svg>';
+
+    expect(sanitizeSvgOutline(safeSvg)).toContain('<svg');
+  });
+
+  it('rejects script tags', () => {
+    const unsafeSvg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><circle cx="20" cy="20" r="10"/></svg>';
+    expect(sanitizeSvgOutline(unsafeSvg)).toBeUndefined();
+  });
+
+  it('rejects event-handler attributes', () => {
+    const unsafeSvg = '<svg xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="10" onclick="alert(1)" /></svg>';
+    expect(sanitizeSvgOutline(unsafeSvg)).toBeUndefined();
+  });
+
+  it('rejects href and javascript protocols', () => {
+    const unsafeSvg = '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><text x="10" y="10">hi</text></a></svg>';
+    expect(sanitizeSvgOutline(unsafeSvg)).toBeUndefined();
+  });
+});

--- a/apps/web-widget/src/utils/svgSanitizer.ts
+++ b/apps/web-widget/src/utils/svgSanitizer.ts
@@ -1,0 +1,116 @@
+const ALLOWED_TAGS = new Set([
+  'svg',
+  'g',
+  'path',
+  'circle',
+  'ellipse',
+  'rect',
+  'line',
+  'polyline',
+  'polygon',
+  'text',
+  'tspan',
+  'defs',
+  'clipPath',
+  'mask',
+  'title',
+  'desc'
+]);
+
+const ALLOWED_ATTRS = new Set([
+  'xmlns',
+  'viewbox',
+  'width',
+  'height',
+  'x',
+  'y',
+  'x1',
+  'x2',
+  'y1',
+  'y2',
+  'cx',
+  'cy',
+  'r',
+  'rx',
+  'ry',
+  'd',
+  'points',
+  'fill',
+  'fill-opacity',
+  'fill-rule',
+  'stroke',
+  'stroke-width',
+  'stroke-opacity',
+  'stroke-linecap',
+  'stroke-linejoin',
+  'stroke-miterlimit',
+  'opacity',
+  'transform',
+  'preserveaspectratio',
+  'id',
+  'class',
+  'role',
+  'aria-hidden',
+  'clip-path',
+  'mask'
+]);
+
+const DISALLOWED_PATTERN =
+  /<\s*(script|foreignObject|iframe|object|embed|link|style|img|image|video|audio|a)\b|on[a-z]+\s*=|javascript:|data:text\/html|xlink:href|href\s*=/i;
+
+const stripXmlPrefix = (value: string): string => value.replace(/^\s*<\?xml[\s\S]*?\?>\s*/i, '');
+
+export const sanitizeSvgOutline = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = stripXmlPrefix(value.trim());
+  if (!trimmed || trimmed.length > 100_000) {
+    return undefined;
+  }
+
+  if (DISALLOWED_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+
+  if (!/^<svg\b[\s\S]*<\/svg>\s*$/i.test(trimmed)) {
+    return undefined;
+  }
+
+  const tagRegex = /<\s*(\/?)\s*([a-zA-Z][\w:-]*)\b([^>]*)>/g;
+  let match: RegExpExecArray | null = tagRegex.exec(trimmed);
+  while (match) {
+    const isClosing = match[1] === '/';
+    const tagName = match[2].toLowerCase();
+    const attrs = match[3] ?? '';
+
+    if (!ALLOWED_TAGS.has(tagName)) {
+      return undefined;
+    }
+
+    if (!isClosing && attrs) {
+      const attrRegex = /([a-zA-Z_:][\w:.-]*)\s*=\s*(".*?"|'.*?'|[^\s"'>]+)/g;
+      let attrMatch: RegExpExecArray | null = attrRegex.exec(attrs);
+      while (attrMatch) {
+        const attrName = attrMatch[1].toLowerCase();
+        const attrValueRaw = attrMatch[2] ?? '';
+        const attrValue = attrValueRaw.replace(/^['"]|['"]$/g, '').trim();
+
+        if (!ALLOWED_ATTRS.has(attrName)) {
+          return undefined;
+        }
+
+        if (/^on/i.test(attrName) || /javascript:|data:text\/html/i.test(attrValue)) {
+          return undefined;
+        }
+
+        attrMatch = attrRegex.exec(attrs);
+      }
+    }
+
+    match = tagRegex.exec(trimmed);
+  }
+
+  return trimmed;
+};


### PR DESCRIPTION
## Summary

* harden `apps/web-widget` rendering paths for tool-produced SVG content
* replace raw trust of outline SVG with a fail-closed sanitizer gate
* reject unsafe SVG payloads before DOM injection
* preserve expected rendering for allowed outline-style SVG
* add focused regression coverage for safe vs unsafe SVG cases

## Scope

* `apps/web-widget` only
* frontend rendering hardening only
* no backend/API/policy changes

## Verification

* `pnpm exec vitest --run apps/web-widget/src/utils/svgSanitizer.test.ts`
* `pnpm --filter web-widget build`
* known unrelated issue:

  * `pnpm --filter web-widget lint` is blocked by a pre-existing ESLint script/config mismatch (`eslint --ext` with flat config)