### PR TITLE
Improve web-widget accessibility for dynamic status updates

### DIFF
--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -40,6 +40,10 @@ export const VoiceBar = () => {
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<VoiceResult | undefined>();
   const [error, setError] = useState<string | undefined>();
+  const blockedMessage = response?.blocked ? response.message ?? 'KidBot paused this request.' : undefined;
+  const statusAnnouncement = loading
+    ? 'KidBot is thinking.'
+    : error ?? blockedMessage ?? (response?.text ? `${response.persona ?? 'KidBot'} reply ready.` : '');
 
   useEffect(() => {
     window.openai?.setWidgetState?.({ tab: 'voice', persona, ageBand, text });
@@ -70,8 +74,16 @@ export const VoiceBar = () => {
   };
 
   return (
-    <section className="panel voice-bar">
+    <section className="panel voice-bar" aria-busy={loading}>
       <h2>Voice Playground</h2>
+      <p
+        className="sr-only"
+        role={error || blockedMessage ? 'alert' : 'status'}
+        aria-live={error || blockedMessage ? 'assertive' : 'polite'}
+        aria-atomic="true"
+      >
+        {statusAnnouncement}
+      </p>
       <div className="control-row">
         <label htmlFor="persona">Persona</label>
         <select id="persona" value={persona} onChange={(event) => setPersona(event.target.value as Persona)}>
@@ -103,7 +115,7 @@ export const VoiceBar = () => {
       {response && (
         <div className="response">
           {response.blocked ? (
-            <p className="blocked">{response.message ?? 'KidBot paused this request.'}</p>
+            <p className="blocked">{blockedMessage}</p>
           ) : (
             <>
               <p>{response.text}</p>

--- a/apps/web-widget/src/styles.css
+++ b/apps/web-widget/src/styles.css
@@ -127,6 +127,18 @@ textarea {
   resize: vertical;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
 .error {
   color: #dc2626;
   font-weight: 600;


### PR DESCRIPTION
Summary
improve accessibility for dynamic status and feedback messaging in apps/web-widget
make loading/error/blocked or similar async states clearer to assistive technologies
preserve existing behavior and styling as much as possible
Scope
apps/web-widget only
frontend accessibility hardening only
no backend/API/policy changes
Verification
pnpm --filter web-widget lint
pnpm --filter web-widget build