### PR TITLE
Improve accessibility parity for web-widget async feedback

### DIFF
--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -47,6 +47,7 @@ export const ColoringBook = () => {
   const [brushColor, setBrushColor] = useState('#2563eb');
   const [brushSize, setBrushSize] = useState(6);
   const [strokes, setStrokes] = useState<Stroke[]>([]);
+  const statusAnnouncement = loading ? 'KidBot is drawing your coloring outline.' : error ?? (outline ? 'Coloring outline ready.' : '');
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const drawingRef = useRef<boolean>(false);
@@ -156,8 +157,11 @@ export const ColoringBook = () => {
   };
 
   return (
-    <section className="panel coloring-book">
+    <section className="panel coloring-book" aria-busy={loading}>
       <h2>Coloring Corner</h2>
+      <p className="sr-only" role={error ? 'alert' : 'status'} aria-live={error ? 'assertive' : 'polite'} aria-atomic="true">
+        {statusAnnouncement}
+      </p>
       <div className="control-row">
         <label htmlFor="scene">Scene</label>
         <input id="scene" value={scene} onChange={(event) => setScene(event.target.value)} />

--- a/apps/web-widget/src/components/ComicBoard.tsx
+++ b/apps/web-widget/src/components/ComicBoard.tsx
@@ -21,6 +21,7 @@ export const ComicBoard = () => {
   const [panels, setPanels] = useState<StoryPanel[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const statusAnnouncement = loading ? 'KidBot is planning story panels.' : error ?? (panels.length > 0 ? `Planned ${panels.length} panels.` : '');
 
   useEffect(() => {
     window.openai?.setWidgetState?.({ tab: 'comics', theme, panelCount, ageBand });
@@ -52,8 +53,11 @@ export const ComicBoard = () => {
   };
 
   return (
-    <section className="panel comic-board">
+    <section className="panel comic-board" aria-busy={loading}>
       <h2>Comic Storyboard</h2>
+      <p className="sr-only" role={error ? 'alert' : 'status'} aria-live={error ? 'assertive' : 'polite'} aria-atomic="true">
+        {statusAnnouncement}
+      </p>
       <div className="control-row">
         <label htmlFor="theme">Theme</label>
         <input id="theme" value={theme} onChange={(event) => setTheme(event.target.value)} />

--- a/apps/web-widget/src/components/ScienceLab.tsx
+++ b/apps/web-widget/src/components/ScienceLab.tsx
@@ -24,6 +24,7 @@ export const ScienceLab = () => {
   const [loading, setLoading] = useState(false);
   const [selectedChoice, setSelectedChoice] = useState<number | undefined>();
   const [showExplanation, setShowExplanation] = useState(false);
+  const statusAnnouncement = loading ? 'KidBot is preparing your science experiment.' : error ?? (plan && !plan.blocked ? `${plan.title ?? 'Experiment'} ready.` : '');
 
   useEffect(() => {
     window.openai?.setWidgetState?.({ tab: 'science', topic, ageBand });
@@ -53,8 +54,11 @@ export const ScienceLab = () => {
   };
 
   return (
-    <section className="panel science-lab">
+    <section className="panel science-lab" aria-busy={loading}>
       <h2>Science Lab</h2>
+      <p className="sr-only" role={error ? 'alert' : 'status'} aria-live={error ? 'assertive' : 'polite'} aria-atomic="true">
+        {statusAnnouncement}
+      </p>
       <div className="control-row">
         <label htmlFor="topic">Topic</label>
         <select id="topic" value={topic} onChange={(event) => setTopic(event.target.value)}>


### PR DESCRIPTION
Summary
extend dynamic accessibility feedback to additional async kid-facing surfaces in apps/web-widget
improve parity for loading/error/blocked/result announcements where appropriate
preserve existing behavior and styling as much as possible
Scope
apps/web-widget only
frontend accessibility hardening only
no backend/API/policy changes
Verification
pnpm --filter web-widget lint
pnpm --filter web-widget build