### PR TITLE
Deduplicate web-widget async accessibility announcement logic

### DIFF
--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -1,5 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { LiveRegion } from './LiveRegion.js';
 import { sanitizeSvgOutline } from '../utils/svgSanitizer.js';
 
 type OutlineStyle = 'animals' | 'space' | 'underwater' | undefined;
@@ -159,9 +160,7 @@ export const ColoringBook = () => {
   return (
     <section className="panel coloring-book" aria-busy={loading}>
       <h2>Coloring Corner</h2>
-      <p className="sr-only" role={error ? 'alert' : 'status'} aria-live={error ? 'assertive' : 'polite'} aria-atomic="true">
-        {statusAnnouncement}
-      </p>
+      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error)} />
       <div className="control-row">
         <label htmlFor="scene">Scene</label>
         <input id="scene" value={scene} onChange={(event) => setScene(event.target.value)} />

--- a/apps/web-widget/src/components/ComicBoard.tsx
+++ b/apps/web-widget/src/components/ComicBoard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { LiveRegion } from './LiveRegion.js';
 
 interface StoryPanel {
   title: string;
@@ -55,9 +56,7 @@ export const ComicBoard = () => {
   return (
     <section className="panel comic-board" aria-busy={loading}>
       <h2>Comic Storyboard</h2>
-      <p className="sr-only" role={error ? 'alert' : 'status'} aria-live={error ? 'assertive' : 'polite'} aria-atomic="true">
-        {statusAnnouncement}
-      </p>
+      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error)} />
       <div className="control-row">
         <label htmlFor="theme">Theme</label>
         <input id="theme" value={theme} onChange={(event) => setTheme(event.target.value)} />

--- a/apps/web-widget/src/components/LiveRegion.tsx
+++ b/apps/web-widget/src/components/LiveRegion.tsx
@@ -1,0 +1,10 @@
+interface LiveRegionProps {
+  message: string;
+  isAlert?: boolean;
+}
+
+export const LiveRegion = ({ message, isAlert = false }: LiveRegionProps) => (
+  <p className="sr-only" role={isAlert ? 'alert' : 'status'} aria-live={isAlert ? 'assertive' : 'polite'} aria-atomic="true">
+    {message}
+  </p>
+);

--- a/apps/web-widget/src/components/ScienceLab.tsx
+++ b/apps/web-widget/src/components/ScienceLab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { LiveRegion } from './LiveRegion.js';
 
 type AgeBand = '4-6' | '7-9' | '10-12';
 
@@ -56,9 +57,7 @@ export const ScienceLab = () => {
   return (
     <section className="panel science-lab" aria-busy={loading}>
       <h2>Science Lab</h2>
-      <p className="sr-only" role={error ? 'alert' : 'status'} aria-live={error ? 'assertive' : 'polite'} aria-atomic="true">
-        {statusAnnouncement}
-      </p>
+      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error)} />
       <div className="control-row">
         <label htmlFor="topic">Topic</label>
         <select id="topic" value={topic} onChange={(event) => setTopic(event.target.value)}>

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { LiveRegion } from './LiveRegion.js';
 
 type Persona = 'robot' | 'fairy' | 'explorer';
 type AgeBand = '4-6' | '7-9' | '10-12';
@@ -76,14 +77,7 @@ export const VoiceBar = () => {
   return (
     <section className="panel voice-bar" aria-busy={loading}>
       <h2>Voice Playground</h2>
-      <p
-        className="sr-only"
-        role={error || blockedMessage ? 'alert' : 'status'}
-        aria-live={error || blockedMessage ? 'assertive' : 'polite'}
-        aria-atomic="true"
-      >
-        {statusAnnouncement}
-      </p>
+      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error || blockedMessage)} />
       <div className="control-row">
         <label htmlFor="persona">Persona</label>
         <select id="persona" value={persona} onChange={(event) => setPersona(event.target.value as Persona)}>


### PR DESCRIPTION
Summary
extract the smallest safe reusable pattern for async accessibility announcements in apps/web-widget
reduce duplication across kid-facing async surfaces
preserve existing behavior, wording, and accessibility semantics
Scope
apps/web-widget only
frontend maintainability improvement only
no backend/API/policy changes
Verification
pnpm --filter web-widget lint
pnpm --filter web-widget build