### PR TITLE
Deduplicate web-widget accessibility announcement logic

### DIFF
--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -2,6 +2,7 @@ import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { sanitizeSvgOutline } from '../utils/svgSanitizer.js';
+import { buildAnnouncementState } from '../utils/announcementState.js';
 
 type OutlineStyle = 'animals' | 'space' | 'underwater' | undefined;
 
@@ -48,7 +49,12 @@ export const ColoringBook = () => {
   const [brushColor, setBrushColor] = useState('#2563eb');
   const [brushSize, setBrushSize] = useState(6);
   const [strokes, setStrokes] = useState<Stroke[]>([]);
-  const statusAnnouncement = loading ? 'KidBot is drawing your coloring outline.' : error ?? (outline ? 'Coloring outline ready.' : '');
+  const announcement = buildAnnouncementState({
+    loading,
+    loadingMessage: 'KidBot is drawing your coloring outline.',
+    errorMessage: error,
+    readyMessage: outline ? 'Coloring outline ready.' : ''
+  });
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const drawingRef = useRef<boolean>(false);
@@ -160,7 +166,7 @@ export const ColoringBook = () => {
   return (
     <section className="panel coloring-book" aria-busy={loading}>
       <h2>Coloring Corner</h2>
-      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error)} />
+      <LiveRegion message={announcement.message} isAlert={announcement.isAlert} />
       <div className="control-row">
         <label htmlFor="scene">Scene</label>
         <input id="scene" value={scene} onChange={(event) => setScene(event.target.value)} />

--- a/apps/web-widget/src/components/ComicBoard.tsx
+++ b/apps/web-widget/src/components/ComicBoard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
+import { buildAnnouncementState } from '../utils/announcementState.js';
 
 interface StoryPanel {
   title: string;
@@ -22,7 +23,12 @@ export const ComicBoard = () => {
   const [panels, setPanels] = useState<StoryPanel[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
-  const statusAnnouncement = loading ? 'KidBot is planning story panels.' : error ?? (panels.length > 0 ? `Planned ${panels.length} panels.` : '');
+  const announcement = buildAnnouncementState({
+    loading,
+    loadingMessage: 'KidBot is planning story panels.',
+    errorMessage: error,
+    readyMessage: panels.length > 0 ? `Planned ${panels.length} panels.` : ''
+  });
 
   useEffect(() => {
     window.openai?.setWidgetState?.({ tab: 'comics', theme, panelCount, ageBand });
@@ -56,7 +62,7 @@ export const ComicBoard = () => {
   return (
     <section className="panel comic-board" aria-busy={loading}>
       <h2>Comic Storyboard</h2>
-      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error)} />
+      <LiveRegion message={announcement.message} isAlert={announcement.isAlert} />
       <div className="control-row">
         <label htmlFor="theme">Theme</label>
         <input id="theme" value={theme} onChange={(event) => setTheme(event.target.value)} />

--- a/apps/web-widget/src/components/ScienceLab.tsx
+++ b/apps/web-widget/src/components/ScienceLab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
+import { buildAnnouncementState } from '../utils/announcementState.js';
 
 type AgeBand = '4-6' | '7-9' | '10-12';
 
@@ -25,7 +26,12 @@ export const ScienceLab = () => {
   const [loading, setLoading] = useState(false);
   const [selectedChoice, setSelectedChoice] = useState<number | undefined>();
   const [showExplanation, setShowExplanation] = useState(false);
-  const statusAnnouncement = loading ? 'KidBot is preparing your science experiment.' : error ?? (plan && !plan.blocked ? `${plan.title ?? 'Experiment'} ready.` : '');
+  const announcement = buildAnnouncementState({
+    loading,
+    loadingMessage: 'KidBot is preparing your science experiment.',
+    errorMessage: error,
+    readyMessage: plan && !plan.blocked ? `${plan.title ?? 'Experiment'} ready.` : ''
+  });
 
   useEffect(() => {
     window.openai?.setWidgetState?.({ tab: 'science', topic, ageBand });
@@ -57,7 +63,7 @@ export const ScienceLab = () => {
   return (
     <section className="panel science-lab" aria-busy={loading}>
       <h2>Science Lab</h2>
-      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error)} />
+      <LiveRegion message={announcement.message} isAlert={announcement.isAlert} />
       <div className="control-row">
         <label htmlFor="topic">Topic</label>
         <select id="topic" value={topic} onChange={(event) => setTopic(event.target.value)}>

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
+import { buildAnnouncementState } from '../utils/announcementState.js';
 
 type Persona = 'robot' | 'fairy' | 'explorer';
 type AgeBand = '4-6' | '7-9' | '10-12';
@@ -42,9 +43,13 @@ export const VoiceBar = () => {
   const [response, setResponse] = useState<VoiceResult | undefined>();
   const [error, setError] = useState<string | undefined>();
   const blockedMessage = response?.blocked ? response.message ?? 'KidBot paused this request.' : undefined;
-  const statusAnnouncement = loading
-    ? 'KidBot is thinking.'
-    : error ?? blockedMessage ?? (response?.text ? `${response.persona ?? 'KidBot'} reply ready.` : '');
+  const announcement = buildAnnouncementState({
+    loading,
+    loadingMessage: 'KidBot is thinking.',
+    errorMessage: error,
+    urgentMessage: blockedMessage,
+    readyMessage: response?.text ? `${response.persona ?? 'KidBot'} reply ready.` : ''
+  });
 
   useEffect(() => {
     window.openai?.setWidgetState?.({ tab: 'voice', persona, ageBand, text });
@@ -77,7 +82,7 @@ export const VoiceBar = () => {
   return (
     <section className="panel voice-bar" aria-busy={loading}>
       <h2>Voice Playground</h2>
-      <LiveRegion message={statusAnnouncement} isAlert={Boolean(error || blockedMessage)} />
+      <LiveRegion message={announcement.message} isAlert={announcement.isAlert} />
       <div className="control-row">
         <label htmlFor="persona">Persona</label>
         <select id="persona" value={persona} onChange={(event) => setPersona(event.target.value as Persona)}>

--- a/apps/web-widget/src/utils/announcementState.ts
+++ b/apps/web-widget/src/utils/announcementState.ts
@@ -1,0 +1,31 @@
+interface AnnouncementStateInput {
+  loading: boolean;
+  loadingMessage: string;
+  errorMessage?: string;
+  urgentMessage?: string;
+  readyMessage?: string;
+}
+
+interface AnnouncementState {
+  message: string;
+  isAlert: boolean;
+}
+
+export const buildAnnouncementState = ({
+  loading,
+  loadingMessage,
+  errorMessage,
+  urgentMessage,
+  readyMessage
+}: AnnouncementStateInput): AnnouncementState => {
+  if (loading) {
+    return { message: loadingMessage, isAlert: false };
+  }
+
+  const alertMessage = errorMessage ?? urgentMessage;
+  if (alertMessage) {
+    return { message: alertMessage, isAlert: true };
+  }
+
+  return { message: readyMessage ?? '', isAlert: false };
+};


### PR DESCRIPTION
## Summary

* extract the smallest safe shared helper for accessibility announcement state in `apps/web-widget`
* reduce repeated live-region logic where duplication is real
* preserve existing wording, behavior, and accessibility semantics

## Scope

* `apps/web-widget` only
* frontend maintainability improvement only
* no backend/API/policy changes

## Verification

* `pnpm --filter web-widget lint`
* `pnpm --filter web-widget build`