### PR TITLE
Align repo docs with current verification behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If installs are blocked, you can still preview the widget and flows:
   - `apps/web-widget/dist/kidbot-fallback.html` in a browser
 
 - Or run the MCP server in fallback mode (if node runs but installs are blocked):
-  - `node apps/mcp-server/src/server.js` (if ts-node isn’t available, open /diag statically)
+  - `node apps/mcp-server/dist/server.js` (if dist artifacts are unavailable, open /diag statically)
 
 - Health & Diag:
   - `/healthz`  -> shows fallback or dist mode


### PR DESCRIPTION
## Summary

* fix one small documentation or verification mismatch caused by recent repo changes
* keep the update factual, minimal, and behavior-preserving
* avoid broad docs churn

## Scope

* minimal docs/scripts only
* no product/runtime/API changes

## Verification

* validated the referenced MCP server entrypoint path exists at `apps/mcp-server/dist/server.js`
* validated the mcp-server start command resolves and launches `dist/server.js` (local run hit `EADDRINUSE` on port 3000)