### PR TITLE
Align repo run and verification instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The `dev` script runs the widget (Vite), MCP server, and agent service together.
 
 ### Verification
 
-- Authoritative full test run: `pnpm -r --if-present run test -- --run`
+- Authoritative recursive test run (packages with a `test` script): `pnpm -r --if-present run test -- --run`
+- MCP compatibility smoke test (not included in recursive `test`): `pnpm --filter mcp-server run test:compat`
 - Root wrapper: `pnpm run test` (runs full recursive tests only when pnpm and workspace dependencies are detectable)
 - If the wrapper prints a smoke-only fallback warning, package Vitest suites were not executed.
 


### PR DESCRIPTION
## Summary
- fix one small, factual mismatch in local run or verification guidance
- keep the correction minimal and behavior-preserving
- avoid broad docs or script churn

## Scope
- minimal docs/scripts only
- no product/runtime/API behavior changes

## Verification
- ran the minimum relevant check for the corrected command or instruction:
  - `pnpm --filter mcp-server run test:compat`