### PR TITLE
Tighten local verification coverage wiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dev": "concurrently -c auto -n WIDGET,MCP,AGENT \"pnpm --filter web-widget dev\" \"pnpm --filter mcp-server dev\" \"pnpm --filter agent-service dev\"",
     "lint": "node ./scripts/run-lint.mjs",
     "typecheck": "node ./scripts/run-typecheck.mjs",
-    "test": "node ./scripts/run-test.mjs"
+    "test": "node ./scripts/run-test.mjs",
+    "test:all": "cross-env CI=1 pnpm -r --if-present run test && pnpm --filter mcp-server run test:compat"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.9.0",


### PR DESCRIPTION
## Summary
- improve one small verification wiring gap exposed by recent MCP compatibility work
- keep the change minimal and behavior-preserving
- avoid broad tooling churn

## Scope
- minimal scripts/tests only
- no product/runtime/API behavior changes

## Verification
- ran the minimum relevant checks for the touched scripts or commands:
  - `pnpm run test:all`