### PR TITLE
Clarify local setup for AGENT_SERVICE_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Copy `.env.example` to `.env` and provide any overrides:
 
 ```
 OPENAI_API_KEY=
+AGENT_SERVICE_TOKEN=
 MCP_PORT=3000
 AGENT_PORT=4505
 ```


### PR DESCRIPTION
## Summary

- clarify one small local setup/docs/example detail for `AGENT_SERVICE_TOKEN`
- align docs/examples with the merged service-auth boundary behavior
- keep the update minimal and factual

## Scope

- minimal docs/examples only
- no product/runtime/API behavior changes

## Verification

- ran the minimum relevant check for the corrected instruction or example:
  - confirmed `AGENT_SERVICE_TOKEN` appears in both `README.md` environment block and `.env.example`