### PR TITLE
Add startup matrix verification for mcp-agent auth flow

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -8,7 +8,8 @@
     "start": "node --enable-source-maps dist/server.js",
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src --max-warnings=0",
-    "test:compat": "node --test test/mcp-compat.test.mjs"
+    "test:compat": "node --test test/mcp-compat.test.mjs",
+    "test:auth-matrix": "node --test test/auth-startup-matrix.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.28.0",

--- a/apps/mcp-server/test/auth-startup-matrix.test.mjs
+++ b/apps/mcp-server/test/auth-startup-matrix.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { randomInt } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { spawn } from 'node:child_process';
+import { test } from 'node:test';
+
+const mcpEntry = join(process.cwd(), 'dist', 'server.js');
+const agentEntry = join(process.cwd(), '../agent-service/dist/index.js');
+
+if (!existsSync(mcpEntry)) {
+  throw new Error('Missing apps/mcp-server/dist/server.js. Run `pnpm --filter mcp-server build` before startup matrix test.');
+}
+
+if (!existsSync(agentEntry)) {
+  throw new Error('Missing apps/agent-service/dist/index.js. Run `pnpm --filter agent-service build` before startup matrix test.');
+}
+
+const toolIds = ['voice_chat', 'story_panels', 'coloring_outline', 'science_sim'];
+
+const spawnProcess = (entry, env) =>
+  spawn(process.execPath, [entry], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ...env
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+const waitForMcpHealth = async (baseUrl) => {
+  for (let i = 0; i < 40; i += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/healthz`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Server may still be starting.
+    }
+    await delay(150);
+  }
+
+  throw new Error(`mcp-server did not become healthy on ${baseUrl}`);
+};
+
+const waitForAgentVoice = async (baseUrl, token) => {
+  for (let i = 0; i < 40; i += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/voice`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          text: 'Tell me a moon fact',
+          persona: 'robot',
+          ageBand: '7-9'
+        })
+      });
+
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Server may still be starting.
+    }
+    await delay(150);
+  }
+
+  throw new Error(`agent-service did not become ready on ${baseUrl}`);
+};
+
+const stopProcess = (child) => {
+  if (child && !child.killed) {
+    child.kill();
+  }
+};
+
+const readExit = async (child, timeoutMs = 3000) =>
+  Promise.race([
+    new Promise((resolve) =>
+      child.on('exit', (code, signal) => {
+        resolve({ code, signal });
+      })
+    ),
+    delay(timeoutMs).then(() => ({ code: null, signal: 'timeout' }))
+  ]);
+
+const callMcp = async (baseUrl, payload) => {
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  return {
+    status: response.status,
+    body: await response.text()
+  };
+};
+
+test('non-fallback mode without AGENT_SERVICE_TOKEN fails closed at mcp startup', async () => {
+  const mcpPort = randomInt(4200, 4699);
+  const mcp = spawnProcess(mcpEntry, {
+    FALLBACK_WIDGET: '0',
+    MCP_PORT: String(mcpPort)
+  });
+
+  let stderr = '';
+  mcp.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    const exit = await readExit(mcp, 3500);
+    assert.notEqual(exit.code, 0);
+    assert.match(stderr, /AGENT_SERVICE_TOKEN is required unless FALLBACK_WIDGET=1/i);
+  } finally {
+    stopProcess(mcp);
+  }
+});
+
+test('non-fallback mode with AGENT_SERVICE_TOKEN allows mcp to call agent-service', async () => {
+  const token = `matrix-token-${randomInt(1000, 9999)}`;
+  const agentPort = randomInt(4700, 5199);
+  const mcpPort = randomInt(5200, 5699);
+  const agentBaseUrl = `http://localhost:${agentPort}`;
+  const mcpBaseUrl = `http://localhost:${mcpPort}`;
+
+  const agent = spawnProcess(agentEntry, {
+    AGENT_SERVICE_TOKEN: token,
+    FALLBACK_WIDGET: '0',
+    OPENAI_API_KEY: '',
+    PORT: String(agentPort)
+  });
+
+  const mcp = spawnProcess(mcpEntry, {
+    AGENT_PORT: String(agentPort),
+    AGENT_SERVICE_TOKEN: token,
+    FALLBACK_WIDGET: '0',
+    MCP_PORT: String(mcpPort)
+  });
+
+  try {
+    await waitForAgentVoice(agentBaseUrl, token);
+    await waitForMcpHealth(mcpBaseUrl);
+
+    const response = await callMcp(mcpBaseUrl, {
+      jsonrpc: '2.0',
+      id: 101,
+      method: 'tools/call',
+      params: {
+        name: 'voice_chat',
+        arguments: {
+          text: 'Tell me a moon fact',
+          persona: 'robot',
+          ageBand: '7-9'
+        }
+      }
+    });
+
+    assert.equal(response.status, 200);
+    assert.match(response.body, /"blocked":false/);
+    assert.match(response.body, /reply ready/i);
+  } finally {
+    stopProcess(mcp);
+    stopProcess(agent);
+  }
+});
+
+test('fallback mode remains explicit bypass path without AGENT_SERVICE_TOKEN', async () => {
+  const mcpPort = randomInt(5700, 6199);
+  const mcpBaseUrl = `http://localhost:${mcpPort}`;
+  const mcp = spawnProcess(mcpEntry, {
+    FALLBACK_WIDGET: '1',
+    MCP_PORT: String(mcpPort)
+  });
+
+  try {
+    await waitForMcpHealth(mcpBaseUrl);
+
+    const response = await callMcp(mcpBaseUrl, {
+      jsonrpc: '2.0',
+      id: 102,
+      method: 'tools/list',
+      params: {}
+    });
+
+    assert.equal(response.status, 200);
+    for (const toolId of toolIds) {
+      assert.match(response.body, new RegExp(`"${toolId}"`));
+    }
+  } finally {
+    stopProcess(mcp);
+  }
+});


### PR DESCRIPTION
## Summary

- add one small executable check for the `mcp-server` ↔ `agent-service` auth/startup matrix
- turn current fallback/auth assumptions into explicit verification
- keep the change narrow, deterministic, and behavior-preserving

## Scope

- focused auth/env verification only
- `apps/mcp-server` and `apps/agent-service` only as needed
- no broad auth redesign
- no widget or deploy/CI changes

## Verification

- ran the new focused matrix verification:
  - `pnpm --filter mcp-server run test:auth-matrix`
- ran the minimum relevant targeted checks for touched packages:
  - `pnpm --filter agent-service build`
  - `pnpm --filter mcp-server build`
  - `pnpm --filter mcp-server run test:compat`