### PR TITLE
Fix web-widget handling for service failure edge case

### DIFF
--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -63,6 +63,7 @@ export const VoiceBar = () => {
 
     setLoading(true);
     setError(undefined);
+    setResponse(undefined);
     try {
       const result = (await window.openai?.callTool?.('voice_chat', { text, persona, ageBand })) as VoiceResult | undefined;
       if (!result) {
@@ -73,6 +74,7 @@ export const VoiceBar = () => {
         speakText(result.text);
       }
     } catch (err) {
+      setResponse(undefined);
       setError(err instanceof Error ? err.message : 'Something went wrong.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

- diagnose one realistic widget/service failure edge case
- fix the smallest confirmed user-visible correctness issue
- keep the change narrow and behavior-preserving

## Scope

- one small bug fix only
- primarily `apps/web-widget`
- no broad refactors or unrelated cleanup

## Verification

- reproduction evidence before fix:
  - after one successful `voice_chat` call, a later failed call (bridge unavailable/service rejection) showed an error while still rendering stale prior response + replay button
- post-fix checks:
  - `pnpm --filter web-widget lint`
  - `pnpm --filter web-widget build`