### PR TITLE
Fix web-widget handling for service failure edge case

### DIFF
--- a/apps/web-widget/src/components/ScienceLab.tsx
+++ b/apps/web-widget/src/components/ScienceLab.tsx
@@ -40,6 +40,7 @@ export const ScienceLab = () => {
   const fetchPlan = async () => {
     setLoading(true);
     setError(undefined);
+    setPlan(undefined);
     setShowExplanation(false);
     setSelectedChoice(undefined);
     try {
@@ -54,6 +55,7 @@ export const ScienceLab = () => {
         setPlan(result);
       }
     } catch (err) {
+      setPlan(undefined);
       setError(err instanceof Error ? err.message : 'Something went wrong.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

- diagnose one realistic widget/service failure edge case
- fix the smallest confirmed user-visible correctness issue
- keep the change narrow and behavior-preserving

## Scope

- one small bug fix only
- primarily `apps/web-widget`
- no broad refactors or unrelated cleanup

## Verification

- reproduction evidence before fix:
  - `ScienceLab` could retain a previously successful plan UI after a later failed/rejected request because the error path did not clear `plan`
- post-fix checks:
  - `pnpm --filter web-widget lint`
  - `pnpm --filter web-widget build`