### PR TITLE
Fix web-widget handling for service failure edge case

### DIFF
--- a/apps/web-widget/src/components/ComicBoard.tsx
+++ b/apps/web-widget/src/components/ComicBoard.tsx
@@ -37,6 +37,7 @@ export const ComicBoard = () => {
   const handlePlan = async () => {
     setLoading(true);
     setError(undefined);
+    setPanels([]);
     try {
       const result = (await window.openai?.callTool?.('story_panels', {
         theme,
@@ -53,6 +54,7 @@ export const ComicBoard = () => {
         setPanels(result.panels ?? []);
       }
     } catch (err) {
+      setPanels([]);
       setError(err instanceof Error ? err.message : 'Something went wrong.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

- diagnose one realistic widget/service failure edge case in `ComicBoard`
- fix the smallest confirmed user-visible correctness issue
- keep the change narrow and behavior-preserving

## Scope

- one small bug fix only
- `apps/web-widget` only
- `ComicBoard` only
- no broad refactors or unrelated cleanup

## Verification

- ran the minimum relevant reproduction and post-fix verification steps:
  - confirmed `ComicBoard` error path previously could leave stale panels visible after a failed/rejected request
  - `pnpm --filter web-widget lint`
  - `pnpm --filter web-widget build`