### PR TITLE
Fix web-widget handling for service failure edge case

### DIFF
--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -138,6 +138,7 @@ export const ColoringBook = () => {
   const fetchOutline = async () => {
     setLoading(true);
     setError(undefined);
+    setOutline(undefined);
     try {
       const result = (await window.openai?.callTool?.('coloring_outline', { scene, style })) as ColoringResponse | undefined;
       if (!result) {
@@ -157,6 +158,7 @@ export const ColoringBook = () => {
       }
       setStrokes([]);
     } catch (err) {
+      setOutline(undefined);
       setError(err instanceof Error ? err.message : 'Something went wrong.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

- diagnose one realistic widget/service failure edge case in `ColoringBook`
- fix the smallest confirmed user-visible correctness issue
- keep the change narrow and behavior-preserving

## Scope

- one small bug fix only
- `apps/web-widget` only
- `ColoringBook` only
- no broad refactors or unrelated cleanup

## Verification

- ran the minimum relevant reproduction and post-fix verification steps:
  - confirmed `ColoringBook` error path previously could leave stale outline visible after a failed/rejected request
  - `pnpm --filter web-widget lint`
  - `pnpm --filter web-widget build`