### PR TITLE
Add minimal component regression test for web-widget

### DIFF
--- a/apps/web-widget/package.json
+++ b/apps/web-widget/package.json
@@ -7,17 +7,21 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings=0"
+    "lint": "eslint src --max-warnings=0",
+    "test": "vitest --run --environment jsdom"
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",
+    "jsdom": "^29.0.1",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.2"
   }
 }

--- a/apps/web-widget/src/components/VoiceBar.staleState.test.tsx
+++ b/apps/web-widget/src/components/VoiceBar.staleState.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VoiceBar } from './VoiceBar.js';
+
+describe('VoiceBar stale-state handling', () => {
+  const callTool = vi.fn();
+
+  beforeEach(() => {
+    callTool.mockReset();
+    (window as { openai?: unknown }).openai = {
+      callTool,
+      setWidgetState: vi.fn()
+    };
+  });
+
+  afterEach(() => {
+    delete (window as { openai?: unknown }).openai;
+  });
+
+  it('clears a previous successful response when a later request fails', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      persona: 'robot',
+      text: 'Space fact ready!'
+    });
+    callTool.mockRejectedValueOnce(new Error('Unauthorized'));
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+    await screen.findByText('Space fact ready!');
+    expect(screen.queryByRole('button', { name: 'Replay' })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+    await waitFor(() => {
+      expect(screen.queryAllByText('Unauthorized').length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Space fact ready!')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Replay' })).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add the smallest viable component-test foundation in `apps/web-widget`
- add one representative regression test for the stale-success-after-failure bug class
- keep the setup narrow, durable, and behavior-focused

## Scope

- `apps/web-widget` only
- minimal test setup and one representative regression test
- no backend/API/policy changes

## Verification

- ran the new representative component test:
  - `pnpm --filter web-widget run test -- src/components/VoiceBar.staleState.test.tsx`
- `pnpm --filter web-widget lint`
- `pnpm --filter web-widget build`