### PR TITLE
Add another focused regression test for web-widget

### DIFF
--- a/apps/web-widget/src/components/ComicBoard.staleState.test.tsx
+++ b/apps/web-widget/src/components/ComicBoard.staleState.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComicBoard } from './ComicBoard.js';
+
+describe('ComicBoard stale-state handling', () => {
+  const callTool = vi.fn();
+
+  beforeEach(() => {
+    callTool.mockReset();
+    (window as { openai?: unknown }).openai = {
+      callTool,
+      setWidgetState: vi.fn()
+    };
+  });
+
+  afterEach(() => {
+    delete (window as { openai?: unknown }).openai;
+  });
+
+  it('clears previous panels when a later request fails', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      panels: [
+        {
+          title: 'Panel One',
+          caption: 'A bright start.',
+          imagePrompt: 'friendly comic panel',
+          imageUrl: null
+        }
+      ]
+    });
+    callTool.mockRejectedValueOnce(new Error('Unauthorized'));
+
+    render(<ComicBoard />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plan Panels' }));
+    await screen.findByText('Panel One');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plan Panels' }));
+    await waitFor(() => {
+      expect(screen.queryAllByText('Unauthorized').length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Panel One')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add one additional high-value regression test in `apps/web-widget`
- reuse the new minimal component-test setup without broadening it
- keep coverage narrow, durable, and behavior-focused

## Scope

- `apps/web-widget` only
- tests only
- no backend/API/policy changes

## Verification

- ran the new targeted regression test:
  - `pnpm --filter web-widget run test -- src/components/ComicBoard.staleState.test.tsx`
- `pnpm --filter web-widget lint`
- `pnpm --filter web-widget build`