### PR TITLE
Add VoiceBar regression test for error and blocked states

### DIFF
--- a/apps/web-widget/src/components/VoiceBar.staleState.test.tsx
+++ b/apps/web-widget/src/components/VoiceBar.staleState.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { VoiceBar } from './VoiceBar.js';
 
@@ -14,6 +14,7 @@ describe('VoiceBar stale-state handling', () => {
   });
 
   afterEach(() => {
+    cleanup();
     delete (window as { openai?: unknown }).openai;
   });
 
@@ -38,6 +39,33 @@ describe('VoiceBar stale-state handling', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Space fact ready!')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Replay' })).toBeNull();
+    });
+  });
+
+  it('shows blocked feedback as an alert and hides previous success UI', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      persona: 'robot',
+      text: 'A happy moon fact.'
+    });
+    callTool.mockResolvedValueOnce({
+      blocked: true,
+      message: 'KidBot paused this request.'
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+    await screen.findByText('A happy moon fact.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+    await waitFor(() => {
+      expect(screen.queryAllByText('KidBot paused this request.').length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('A happy moon fact.')).toBeNull();
       expect(screen.queryByRole('button', { name: 'Replay' })).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

- add one focused regression test for `VoiceBar` blocked/error behavior
- reuse the existing minimal component-test setup without broadening it
- keep coverage narrow, durable, and behavior-focused

## Scope

- `apps/web-widget` only
- tests only
- no backend/API/policy changes

## Verification

- ran the new targeted regression test:
  - `pnpm --filter web-widget run test -- src/components/VoiceBar.staleState.test.tsx`
- `pnpm --filter web-widget lint`
- `pnpm --filter web-widget build`