### PR TITLE
[codex] Tighten provider degradation UX

### DIFF
--- a/apps/mcp-server/src/tools.ts
+++ b/apps/mcp-server/src/tools.ts
@@ -18,6 +18,7 @@ const fallbackMode = process.env.FALLBACK_WIDGET === '1';
 const localDevIntent = process.env.KIDBOT_LOCAL_DEV === '1';
 const serviceAuthToken = process.env.AGENT_SERVICE_TOKEN?.trim();
 const startupPosture = fallbackMode ? 'local-fallback' : 'secured';
+const degradedServiceMessage = 'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.';
 
 if (fallbackMode && !localDevIntent) {
   throw new Error('FALLBACK_WIDGET=1 requires KIDBOT_LOCAL_DEV=1 for explicit local fallback posture.');
@@ -35,7 +36,18 @@ const outputMeta = {
   }
 };
 
-const callAgent = async <T>(path: string, payload: unknown): Promise<T> => {
+interface AgentDegradedResponse {
+  blocked: false;
+  degraded: true;
+  message: string;
+  fallbackReason?: string;
+  correlationId?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const callAgent = async <T>(path: string, payload: unknown): Promise<T | AgentDegradedResponse> => {
   if (fallbackMode) {
     throw new Error('Agent disabled in fallback mode');
   }
@@ -49,11 +61,28 @@ const callAgent = async <T>(path: string, payload: unknown): Promise<T> => {
     body: JSON.stringify(payload)
   });
 
+  const responseBody = (await response.json().catch(() => undefined)) as unknown;
+
   if (!response.ok) {
+    if (response.status === 503) {
+      const fallbackReason = isRecord(responseBody) && typeof responseBody.fallbackReason === 'string'
+        ? responseBody.fallbackReason
+        : undefined;
+      const correlationId = isRecord(responseBody) && typeof responseBody.correlationId === 'string'
+        ? responseBody.correlationId
+        : undefined;
+      return {
+        blocked: false,
+        degraded: true,
+        message: degradedServiceMessage,
+        fallbackReason,
+        correlationId
+      };
+    }
     throw new Error(`Agent request failed with status ${response.status}`);
   }
 
-  return (await response.json()) as T;
+  return responseBody as T;
 };
 
 const blockedResponse = (message: string) => ({
@@ -72,7 +101,24 @@ const blockedResponse = (message: string) => ({
   }
 });
 
-const handleWithModeration = async <Schema extends z.ZodTypeAny, ResponseType extends { blocked: boolean; message?: string }>(
+const isDegradedResponse = (response: { degraded?: boolean }): response is AgentDegradedResponse =>
+  response.degraded === true;
+
+const degradedResponse = (response: AgentDegradedResponse) => ({
+  content: [
+    {
+      type: 'text' as const,
+      text: response.message
+    }
+  ],
+  structuredContent: response as unknown as Record<string, unknown>,
+  _meta: {
+    ...outputMeta,
+    'openai/widgetAccessible': true
+  }
+});
+
+const handleWithModeration = async <Schema extends z.ZodTypeAny, ResponseType extends { blocked: boolean; message?: string; degraded?: boolean }>(
   schema: Schema,
   payload: unknown,
   validator: (input: z.infer<Schema>) => string[],
@@ -87,6 +133,10 @@ const handleWithModeration = async <Schema extends z.ZodTypeAny, ResponseType ex
   }
 
   const agentResponse = await action(parsed);
+  if (isDegradedResponse(agentResponse)) {
+    return degradedResponse(agentResponse);
+  }
+
   if (agentResponse.blocked) {
     return blockedResponse(agentResponse.message ?? 'Let\'s pick another playful request.');
   }
@@ -244,7 +294,7 @@ export const registerTools = (server: McpServer): void => {
         (data, response) =>
           response.blocked
             ? response.message ?? 'Kidbot paused this request.'
-            : `${data.persona} reply ready! ${response.text ?? ''}`
+            : `${data.persona} reply ready! ${'text' in response ? response.text ?? '' : ''}`
       ));
 
   const storyTool = {

--- a/apps/mcp-server/test/auth-startup-matrix.test.mjs
+++ b/apps/mcp-server/test/auth-startup-matrix.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { randomInt } from 'node:crypto';
+import { createServer } from 'node:http';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
@@ -10,11 +11,15 @@ const mcpEntry = join(process.cwd(), 'dist', 'server.js');
 const agentEntry = join(process.cwd(), '../agent-service/dist/index.js');
 
 if (!existsSync(mcpEntry)) {
-  throw new Error('Missing apps/mcp-server/dist/server.js. Run `pnpm --filter mcp-server build` before startup matrix test.');
+  throw new Error(
+    'Missing apps/mcp-server/dist/server.js. Run `pnpm --filter mcp-server build` before startup matrix test.',
+  );
 }
 
 if (!existsSync(agentEntry)) {
-  throw new Error('Missing apps/agent-service/dist/index.js. Run `pnpm --filter agent-service build` before startup matrix test.');
+  throw new Error(
+    'Missing apps/agent-service/dist/index.js. Run `pnpm --filter agent-service build` before startup matrix test.',
+  );
 }
 
 const toolIds = ['voice_chat', 'story_panels', 'coloring_outline', 'science_sim'];
@@ -24,9 +29,9 @@ const spawnProcess = (entry, env) =>
     cwd: process.cwd(),
     env: {
       ...process.env,
-      ...env
+      ...env,
     },
-    stdio: ['ignore', 'pipe', 'pipe']
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
 
 const waitForMcpHealth = async (baseUrl) => {
@@ -52,7 +57,7 @@ const waitForAgentVoice = async (baseUrl, token, postureHeader = 'secured') => {
     try {
       const headers = {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       };
       if (postureHeader) {
         headers['x-kidbot-startup-posture'] = postureHeader;
@@ -63,8 +68,8 @@ const waitForAgentVoice = async (baseUrl, token, postureHeader = 'secured') => {
         body: JSON.stringify({
           text: 'Tell me a moon fact',
           persona: 'robot',
-          ageBand: '7-9'
-        })
+          ageBand: '7-9',
+        }),
       });
 
       lastStatus = response.status;
@@ -78,7 +83,9 @@ const waitForAgentVoice = async (baseUrl, token, postureHeader = 'secured') => {
     await delay(150);
   }
 
-  throw new Error(`agent-service did not become ready on ${baseUrl}; lastStatus=${lastStatus}; lastBody=${lastBody}`);
+  throw new Error(
+    `agent-service did not become ready on ${baseUrl}; lastStatus=${lastStatus}; lastBody=${lastBody}`,
+  );
 };
 
 const stopProcess = (child) => {
@@ -92,9 +99,9 @@ const readExit = async (child, timeoutMs = 3000) =>
     new Promise((resolve) =>
       child.on('exit', (code, signal) => {
         resolve({ code, signal });
-      })
+      }),
     ),
-    delay(timeoutMs).then(() => ({ code: null, signal: 'timeout' }))
+    delay(timeoutMs).then(() => ({ code: null, signal: 'timeout' })),
   ]);
 
 const callMcp = async (baseUrl, payload) => {
@@ -102,22 +109,38 @@ const callMcp = async (baseUrl, payload) => {
     method: 'POST',
     headers: {
       Accept: 'application/json, text/event-stream',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload)
+    body: JSON.stringify(payload),
   });
 
   return {
     status: response.status,
-    body: await response.text()
+    body: await response.text(),
   };
 };
+
+const listen = (server, port) =>
+  new Promise((resolve) => {
+    server.listen(port, resolve);
+  });
+
+const closeServer = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
 
 test('non-fallback mode without AGENT_SERVICE_TOKEN fails closed at mcp startup', async () => {
   const mcpPort = randomInt(4200, 4699);
   const mcp = spawnProcess(mcpEntry, {
     FALLBACK_WIDGET: '0',
-    MCP_PORT: String(mcpPort)
+    MCP_PORT: String(mcpPort),
   });
 
   let stderr = '';
@@ -145,14 +168,14 @@ test('non-fallback mode with AGENT_SERVICE_TOKEN allows mcp to call agent-servic
     AGENT_SERVICE_TOKEN: token,
     FALLBACK_WIDGET: '0',
     OPENAI_API_KEY: '',
-    PORT: String(agentPort)
+    PORT: String(agentPort),
   });
 
   const mcp = spawnProcess(mcpEntry, {
     AGENT_PORT: String(agentPort),
     AGENT_SERVICE_TOKEN: token,
     FALLBACK_WIDGET: '0',
-    MCP_PORT: String(mcpPort)
+    MCP_PORT: String(mcpPort),
   });
 
   try {
@@ -168,9 +191,9 @@ test('non-fallback mode with AGENT_SERVICE_TOKEN allows mcp to call agent-servic
         arguments: {
           text: 'Tell me a moon fact',
           persona: 'robot',
-          ageBand: '7-9'
-        }
-      }
+          ageBand: '7-9',
+        },
+      },
     });
 
     assert.equal(response.status, 200);
@@ -188,7 +211,7 @@ test('fallback mode remains explicit bypass path without AGENT_SERVICE_TOKEN', a
   const mcp = spawnProcess(mcpEntry, {
     FALLBACK_WIDGET: '1',
     KIDBOT_LOCAL_DEV: '1',
-    MCP_PORT: String(mcpPort)
+    MCP_PORT: String(mcpPort),
   });
 
   try {
@@ -198,7 +221,7 @@ test('fallback mode remains explicit bypass path without AGENT_SERVICE_TOKEN', a
       jsonrpc: '2.0',
       id: 102,
       method: 'tools/list',
-      params: {}
+      params: {},
     });
 
     assert.equal(response.status, 200);
@@ -214,7 +237,7 @@ test('fallback mode without KIDBOT_LOCAL_DEV fails closed at mcp startup', async
   const mcpPort = randomInt(6200, 6699);
   const mcp = spawnProcess(mcpEntry, {
     FALLBACK_WIDGET: '1',
-    MCP_PORT: String(mcpPort)
+    MCP_PORT: String(mcpPort),
   });
 
   let stderr = '';
@@ -242,14 +265,14 @@ test('mcp secured posture fails loudly when agent runs local fallback posture', 
     FALLBACK_WIDGET: '1',
     KIDBOT_LOCAL_DEV: '1',
     OPENAI_API_KEY: '',
-    PORT: String(agentPort)
+    PORT: String(agentPort),
   });
 
   const mcp = spawnProcess(mcpEntry, {
     AGENT_PORT: String(agentPort),
     AGENT_SERVICE_TOKEN: token,
     FALLBACK_WIDGET: '0',
-    MCP_PORT: String(mcpPort)
+    MCP_PORT: String(mcpPort),
   });
 
   try {
@@ -265,9 +288,9 @@ test('mcp secured posture fails loudly when agent runs local fallback posture', 
         arguments: {
           text: 'Tell me a moon fact',
           persona: 'robot',
-          ageBand: '7-9'
-        }
-      }
+          ageBand: '7-9',
+        },
+      },
     });
 
     assert.equal(response.status, 200);
@@ -275,5 +298,65 @@ test('mcp secured posture fails loudly when agent runs local fallback posture', 
   } finally {
     stopProcess(mcp);
     stopProcess(agent);
+  }
+});
+
+test('mcp surfaces provider 503 as degraded content instead of a safety block', async () => {
+  const token = `matrix-token-${randomInt(1000, 9999)}`;
+  const agentPort = randomInt(7700, 8199);
+  const mcpPort = randomInt(8200, 8699);
+  const mcpBaseUrl = `http://localhost:${mcpPort}`;
+
+  const fakeAgent = createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/voice') {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'Service temporarily degraded',
+          fallbackReason: 'generation_timeout',
+          correlationId: 'kb_test_degraded',
+        }),
+      );
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  });
+
+  await listen(fakeAgent, agentPort);
+
+  const mcp = spawnProcess(mcpEntry, {
+    AGENT_PORT: String(agentPort),
+    AGENT_SERVICE_TOKEN: token,
+    FALLBACK_WIDGET: '0',
+    MCP_PORT: String(mcpPort),
+  });
+
+  try {
+    await waitForMcpHealth(mcpBaseUrl);
+
+    const response = await callMcp(mcpBaseUrl, {
+      jsonrpc: '2.0',
+      id: 104,
+      method: 'tools/call',
+      params: {
+        name: 'voice_chat',
+        arguments: {
+          text: 'Tell me a moon fact',
+          persona: 'robot',
+          ageBand: '7-9',
+        },
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.match(response.body, /"blocked":false/);
+    assert.match(response.body, /"degraded":true/);
+    assert.match(response.body, /"fallbackReason":"generation_timeout"/);
+    assert.match(response.body, /idea engine right now/i);
+  } finally {
+    stopProcess(mcp);
+    await closeServer(fakeAgent);
   }
 });

--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -3,11 +3,17 @@ import { useEffect, useRef, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { sanitizeSvgOutline } from '../utils/svgSanitizer.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
+import {
+  degradedMessage,
+  errorMessage,
+  unavailableMessageFromError,
+} from '../utils/degradation.js';
 
 type OutlineStyle = 'animals' | 'space' | 'underwater' | undefined;
 
 interface ColoringResponse {
   blocked: boolean;
+  degraded?: boolean;
   message?: string;
   svg?: string;
 }
@@ -50,6 +56,7 @@ export const ColoringBook = () => {
   const [outline, setOutline] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const [unavailable, setUnavailable] = useState<string | undefined>();
   const [brushColor, setBrushColor] = useState('#2563eb');
   const [brushSize, setBrushSize] = useState(6);
   const [strokes, setStrokes] = useState<Stroke[]>([]);
@@ -57,6 +64,7 @@ export const ColoringBook = () => {
     loading,
     loadingMessage: 'Kidbot is drawing your coloring outline.',
     errorMessage: error,
+    urgentMessage: unavailable,
     readyMessage: outline ? 'Coloring outline ready.' : '',
   });
 
@@ -142,6 +150,7 @@ export const ColoringBook = () => {
   const fetchOutline = async () => {
     setLoading(true);
     setError(undefined);
+    setUnavailable(undefined);
     setOutline(undefined);
     try {
       const result = (await window.openai?.callTool?.('coloring_outline', { scene, style })) as
@@ -150,7 +159,11 @@ export const ColoringBook = () => {
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }
-      if (result.blocked) {
+      const unavailableMessage = degradedMessage(result);
+      if (unavailableMessage) {
+        setOutline(undefined);
+        setUnavailable(unavailableMessage);
+      } else if (result.blocked) {
         setOutline(undefined);
         setError(result.message ?? 'Kidbot paused this outline request.');
       } else {
@@ -165,7 +178,12 @@ export const ColoringBook = () => {
       setStrokes([]);
     } catch (err) {
       setOutline(undefined);
-      setError(err instanceof Error ? err.message : 'Something went wrong.');
+      const unavailableMessage = unavailableMessageFromError(err);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+      } else {
+        setError(errorMessage(err));
+      }
     } finally {
       setLoading(false);
     }
@@ -196,6 +214,7 @@ export const ColoringBook = () => {
         </button>
       </div>
       {error && <p className="error">{error}</p>}
+      {unavailable && <p className="degraded">{unavailable}</p>}
       <div className="coloring-stage">
         <div className="canvas-wrapper">
           <canvas

--- a/apps/web-widget/src/components/ComicBoard.staleState.test.tsx
+++ b/apps/web-widget/src/components/ComicBoard.staleState.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComicBoard } from './ComicBoard.js';
 
@@ -9,11 +9,12 @@ describe('ComicBoard stale-state handling', () => {
     callTool.mockReset();
     (window as { openai?: unknown }).openai = {
       callTool,
-      setWidgetState: vi.fn()
+      setWidgetState: vi.fn(),
     };
   });
 
   afterEach(() => {
+    cleanup();
     delete (window as { openai?: unknown }).openai;
   });
 
@@ -25,9 +26,9 @@ describe('ComicBoard stale-state handling', () => {
           title: 'Panel One',
           caption: 'A bright start.',
           imagePrompt: 'friendly comic panel',
-          imageUrl: null
-        }
-      ]
+          imageUrl: null,
+        },
+      ],
     });
     callTool.mockRejectedValueOnce(new Error('Unauthorized'));
 
@@ -44,5 +45,27 @@ describe('ComicBoard stale-state handling', () => {
     await waitFor(() => {
       expect(screen.queryByText('Panel One')).toBeNull();
     });
+  });
+
+  it('shows provider degradation without rendering it as a story safety pause', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      degraded: true,
+      message:
+        'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+    });
+
+    render(<ComicBoard />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plan Panels' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('Kidbot paused this story idea.')).toBeNull();
   });
 });

--- a/apps/web-widget/src/components/ComicBoard.tsx
+++ b/apps/web-widget/src/components/ComicBoard.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
+import {
+  degradedMessage,
+  errorMessage,
+  unavailableMessageFromError,
+} from '../utils/degradation.js';
 
 interface StoryPanel {
   title: string;
@@ -11,6 +16,7 @@ interface StoryPanel {
 
 interface StoryResponse {
   blocked: boolean;
+  degraded?: boolean;
   message?: string;
   theme?: string;
   panels?: StoryPanel[];
@@ -23,11 +29,13 @@ export const ComicBoard = () => {
   const [panels, setPanels] = useState<StoryPanel[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const [unavailable, setUnavailable] = useState<string | undefined>();
   const announcement = buildAnnouncementState({
     loading,
     loadingMessage: 'Kidbot is planning story panels.',
     errorMessage: error,
-    readyMessage: panels.length > 0 ? `Planned ${panels.length} panels.` : ''
+    urgentMessage: unavailable,
+    readyMessage: panels.length > 0 ? `Planned ${panels.length} panels.` : '',
   });
 
   useEffect(() => {
@@ -37,17 +45,21 @@ export const ComicBoard = () => {
   const handlePlan = async () => {
     setLoading(true);
     setError(undefined);
+    setUnavailable(undefined);
     setPanels([]);
     try {
       const result = (await window.openai?.callTool?.('story_panels', {
         theme,
         panels: panelCount,
-        ageBand
+        ageBand,
       })) as StoryResponse | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }
-      if (result.blocked) {
+      const unavailableMessage = degradedMessage(result);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+      } else if (result.blocked) {
         setPanels([]);
         setError(result.message ?? 'Kidbot paused this story idea.');
       } else {
@@ -55,7 +67,12 @@ export const ComicBoard = () => {
       }
     } catch (err) {
       setPanels([]);
-      setError(err instanceof Error ? err.message : 'Something went wrong.');
+      const unavailableMessage = unavailableMessageFromError(err);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+      } else {
+        setError(errorMessage(err));
+      }
     } finally {
       setLoading(false);
     }
@@ -78,7 +95,11 @@ export const ComicBoard = () => {
           onChange={(event) => setPanelCount(Number(event.target.value))}
         />
         <label htmlFor="panel-age">Age</label>
-        <select id="panel-age" value={ageBand} onChange={(event) => setAgeBand(event.target.value as '4-6' | '7-9' | '10-12')}>
+        <select
+          id="panel-age"
+          value={ageBand}
+          onChange={(event) => setAgeBand(event.target.value as '4-6' | '7-9' | '10-12')}
+        >
           <option value="4-6">Ages 4-6</option>
           <option value="7-9">Ages 7-9</option>
           <option value="10-12">Ages 10-12</option>
@@ -88,6 +109,7 @@ export const ComicBoard = () => {
         </button>
       </div>
       {error && <p className="error">{error}</p>}
+      {unavailable && <p className="degraded">{unavailable}</p>}
       <div className="panel-grid">
         {panels.map((panel) => (
           <article key={panel.title} className="panel-card">

--- a/apps/web-widget/src/components/ScienceLab.tsx
+++ b/apps/web-widget/src/components/ScienceLab.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
+import {
+  degradedMessage,
+  errorMessage,
+  unavailableMessageFromError,
+} from '../utils/degradation.js';
 
 type AgeBand = '4-6' | '7-9' | '10-12';
 
 interface ScienceResponse {
   blocked: boolean;
+  degraded?: boolean;
   message?: string;
   title?: string;
   objective?: string;
@@ -23,6 +29,7 @@ export const ScienceLab = () => {
   const [ageBand, setAgeBand] = useState<AgeBand>('7-9');
   const [plan, setPlan] = useState<ScienceResponse | undefined>();
   const [error, setError] = useState<string | undefined>();
+  const [unavailable, setUnavailable] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
   const [selectedChoice, setSelectedChoice] = useState<number | undefined>();
   const [showExplanation, setShowExplanation] = useState(false);
@@ -30,7 +37,8 @@ export const ScienceLab = () => {
     loading,
     loadingMessage: 'Kidbot is preparing your science experiment.',
     errorMessage: error,
-    readyMessage: plan && !plan.blocked ? `${plan.title ?? 'Experiment'} ready.` : ''
+    urgentMessage: unavailable,
+    readyMessage: plan && !plan.blocked ? `${plan.title ?? 'Experiment'} ready.` : '',
   });
 
   useEffect(() => {
@@ -40,15 +48,21 @@ export const ScienceLab = () => {
   const fetchPlan = async () => {
     setLoading(true);
     setError(undefined);
+    setUnavailable(undefined);
     setPlan(undefined);
     setShowExplanation(false);
     setSelectedChoice(undefined);
     try {
-      const result = (await window.openai?.callTool?.('science_sim', { topic, ageBand })) as ScienceResponse | undefined;
+      const result = (await window.openai?.callTool?.('science_sim', { topic, ageBand })) as
+        | ScienceResponse
+        | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }
-      if (result.blocked) {
+      const unavailableMessage = degradedMessage(result);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+      } else if (result.blocked) {
         setPlan(undefined);
         setError(result.message ?? 'Kidbot paused this experiment.');
       } else {
@@ -56,7 +70,12 @@ export const ScienceLab = () => {
       }
     } catch (err) {
       setPlan(undefined);
-      setError(err instanceof Error ? err.message : 'Something went wrong.');
+      const unavailableMessage = unavailableMessageFromError(err);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+      } else {
+        setError(errorMessage(err));
+      }
     } finally {
       setLoading(false);
     }
@@ -76,7 +95,11 @@ export const ScienceLab = () => {
           ))}
         </select>
         <label htmlFor="science-age">Age</label>
-        <select id="science-age" value={ageBand} onChange={(event) => setAgeBand(event.target.value as AgeBand)}>
+        <select
+          id="science-age"
+          value={ageBand}
+          onChange={(event) => setAgeBand(event.target.value as AgeBand)}
+        >
           <option value="4-6">Ages 4-6</option>
           <option value="7-9">Ages 7-9</option>
           <option value="10-12">Ages 10-12</option>
@@ -86,6 +109,7 @@ export const ScienceLab = () => {
         </button>
       </div>
       {error && <p className="error">{error}</p>}
+      {unavailable && <p className="degraded">{unavailable}</p>}
       {plan && !plan.blocked && (
         <article className="experiment-card">
           <h3>{plan.title}</h3>
@@ -131,7 +155,10 @@ export const ScienceLab = () => {
               </button>
               {showExplanation && plan.explanation && (
                 <p className="explanation">
-                  {plan.explanation} {selectedChoice === plan.prediction.answerIndex ? '✅ Great prediction!' : 'Let\'s explore why!'}
+                  {plan.explanation}{' '}
+                  {selectedChoice === plan.prediction.answerIndex
+                    ? '✅ Great prediction!'
+                    : "Let's explore why!"}
                 </p>
               )}
             </div>

--- a/apps/web-widget/src/components/VoiceBar.staleState.test.tsx
+++ b/apps/web-widget/src/components/VoiceBar.staleState.test.tsx
@@ -9,7 +9,7 @@ describe('VoiceBar stale-state handling', () => {
     callTool.mockReset();
     (window as { openai?: unknown }).openai = {
       callTool,
-      setWidgetState: vi.fn()
+      setWidgetState: vi.fn(),
     };
   });
 
@@ -22,7 +22,7 @@ describe('VoiceBar stale-state handling', () => {
     callTool.mockResolvedValueOnce({
       blocked: false,
       persona: 'robot',
-      text: 'Space fact ready!'
+      text: 'Space fact ready!',
     });
     callTool.mockRejectedValueOnce(new Error('Unauthorized'));
 
@@ -47,11 +47,11 @@ describe('VoiceBar stale-state handling', () => {
     callTool.mockResolvedValueOnce({
       blocked: false,
       persona: 'robot',
-      text: 'A happy moon fact.'
+      text: 'A happy moon fact.',
     });
     callTool.mockResolvedValueOnce({
       blocked: true,
-      message: 'KidBot paused this request.'
+      message: 'KidBot paused this request.',
     });
 
     render(<VoiceBar />);
@@ -68,5 +68,45 @@ describe('VoiceBar stale-state handling', () => {
       expect(screen.queryByText('A happy moon fact.')).toBeNull();
       expect(screen.queryByRole('button', { name: 'Replay' })).toBeNull();
     });
+  });
+
+  it('shows provider degradation as unavailable instead of a safety block', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      degraded: true,
+      message:
+        'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('Kidbot paused this request.')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Replay' })).toBeNull();
+  });
+
+  it('maps rejected 503 provider failures to the unavailable state', async () => {
+    callTool.mockRejectedValueOnce(new Error('Agent request failed with status 503'));
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('Agent request failed with status 503')).toBeNull();
   });
 });

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
+import {
+  degradedMessage,
+  errorMessage,
+  unavailableMessageFromError,
+} from '../utils/degradation.js';
 
 type Persona = 'robot' | 'fairy' | 'explorer';
 type AgeBand = '4-6' | '7-9' | '10-12';
 
 interface VoiceResult {
   blocked: boolean;
+  degraded?: boolean;
   message?: string;
   persona?: Persona;
   text?: string;
@@ -16,13 +22,13 @@ interface VoiceResult {
 const personas: Array<{ key: Persona; label: string }> = [
   { key: 'robot', label: 'Robot Buddy' },
   { key: 'fairy', label: 'Fairy Friend' },
-  { key: 'explorer', label: 'Explorer Pal' }
+  { key: 'explorer', label: 'Explorer Pal' },
 ];
 
 const ageBands: Array<{ key: AgeBand; label: string }> = [
   { key: '4-6', label: 'Ages 4-6' },
   { key: '7-9', label: 'Ages 7-9' },
-  { key: '10-12', label: 'Ages 10-12' }
+  { key: '10-12', label: 'Ages 10-12' },
 ];
 
 const speakText = (text: string) => {
@@ -42,13 +48,16 @@ export const VoiceBar = () => {
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<VoiceResult | undefined>();
   const [error, setError] = useState<string | undefined>();
-  const blockedMessage = response?.blocked ? response.message ?? 'Kidbot paused this request.' : undefined;
+  const [unavailable, setUnavailable] = useState<string | undefined>();
+  const blockedMessage = response?.blocked
+    ? (response.message ?? 'Kidbot paused this request.')
+    : undefined;
   const announcement = buildAnnouncementState({
     loading,
     loadingMessage: 'Kidbot is thinking.',
     errorMessage: error,
-    urgentMessage: blockedMessage,
-    readyMessage: response?.text ? `${response.persona ?? 'Kidbot'} reply ready.` : ''
+    urgentMessage: unavailable ?? blockedMessage,
+    readyMessage: response?.text ? `${response.persona ?? 'Kidbot'} reply ready.` : '',
   });
 
   useEffect(() => {
@@ -63,11 +72,19 @@ export const VoiceBar = () => {
 
     setLoading(true);
     setError(undefined);
+    setUnavailable(undefined);
     setResponse(undefined);
     try {
-      const result = (await window.openai?.callTool?.('voice_chat', { text, persona, ageBand })) as VoiceResult | undefined;
+      const result = (await window.openai?.callTool?.('voice_chat', { text, persona, ageBand })) as
+        | VoiceResult
+        | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
+      }
+      const unavailableMessage = degradedMessage(result);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+        return;
       }
       setResponse(result);
       if (!result.blocked && result.text) {
@@ -75,7 +92,12 @@ export const VoiceBar = () => {
       }
     } catch (err) {
       setResponse(undefined);
-      setError(err instanceof Error ? err.message : 'Something went wrong.');
+      const unavailableMessage = unavailableMessageFromError(err);
+      if (unavailableMessage) {
+        setUnavailable(unavailableMessage);
+      } else {
+        setError(errorMessage(err));
+      }
     } finally {
       setLoading(false);
     }
@@ -87,7 +109,11 @@ export const VoiceBar = () => {
       <LiveRegion message={announcement.message} isAlert={announcement.isAlert} />
       <div className="control-row">
         <label htmlFor="persona">Persona</label>
-        <select id="persona" value={persona} onChange={(event) => setPersona(event.target.value as Persona)}>
+        <select
+          id="persona"
+          value={persona}
+          onChange={(event) => setPersona(event.target.value as Persona)}
+        >
           {personas.map((option) => (
             <option key={option.key} value={option.key}>
               {option.label}
@@ -95,7 +121,11 @@ export const VoiceBar = () => {
           ))}
         </select>
         <label htmlFor="ageBand">Age</label>
-        <select id="ageBand" value={ageBand} onChange={(event) => setAgeBand(event.target.value as AgeBand)}>
+        <select
+          id="ageBand"
+          value={ageBand}
+          onChange={(event) => setAgeBand(event.target.value as AgeBand)}
+        >
           {ageBands.map((option) => (
             <option key={option.key} value={option.key}>
               {option.label}
@@ -113,6 +143,7 @@ export const VoiceBar = () => {
         {loading ? 'Thinking...' : 'Speak'}
       </button>
       {error && <p className="error">{error}</p>}
+      {unavailable && <p className="degraded">{unavailable}</p>}
       {response && (
         <div className="response">
           {response.blocked ? (

--- a/apps/web-widget/src/styles.css
+++ b/apps/web-widget/src/styles.css
@@ -46,7 +46,9 @@ body {
   color: #1e3a8a;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, background 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
 }
 
 .kidbot-header button.active,
@@ -100,7 +102,9 @@ main {
   border-radius: 999px;
   padding: 0.6rem 1.3rem;
   cursor: pointer;
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 .panel button:disabled {
@@ -147,6 +151,16 @@ textarea {
 .blocked {
   color: #ea580c;
   font-weight: 600;
+}
+
+.degraded {
+  color: #075985;
+  background: #e0f2fe;
+  border: 2px solid #7dd3fc;
+  border-radius: 16px;
+  font-weight: 700;
+  margin: 0;
+  padding: 0.85rem 1rem;
 }
 
 .response {

--- a/apps/web-widget/src/utils/degradation.ts
+++ b/apps/web-widget/src/utils/degradation.ts
@@ -1,0 +1,24 @@
+export const SERVICE_UNAVAILABLE_MESSAGE =
+  'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.';
+
+export interface DegradedResult {
+  degraded?: boolean;
+  message?: string;
+}
+
+export const degradedMessage = (result: DegradedResult): string | undefined =>
+  result.degraded ? (result.message ?? SERVICE_UNAVAILABLE_MESSAGE) : undefined;
+
+export const unavailableMessageFromError = (error: unknown): string | undefined => {
+  if (
+    error instanceof Error &&
+    /503|temporarily degraded|temporarily unavailable/i.test(error.message)
+  ) {
+    return SERVICE_UNAVAILABLE_MESSAGE;
+  }
+
+  return undefined;
+};
+
+export const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : 'Something went wrong.';


### PR DESCRIPTION
## Summary

- map agent-service 503 responses in MCP to structured `degraded: true` content instead of throwing generic tool errors
- show a friendly unavailable state in each widget surface without reusing safety-block UI
- add regression coverage for MCP provider 503 handling and widget degraded-state rendering

## Verification

- pnpm --filter @kidbot/mcp-server run build
- pnpm --filter @kidbot/mcp-server run test:auth-matrix
- pnpm --filter @kidbot/mcp-server run test:compat
- pnpm --filter @kidbot/web-widget run test
- pnpm --filter @kidbot/web-widget run build
- pnpm exec eslint src/tools.ts --max-warnings=0 (from apps/mcp-server)
- pnpm exec eslint src --max-warnings=0 (from apps/web-widget)

## Note

Full `pnpm --filter @kidbot/mcp-server run lint` still fails on an existing `src/server.ts` no-misused-promises finding outside this change.