### PR TITLE
[codex] Add full stack CI with Redis smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  full-stack:
+    name: Full Stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      CI: '1'
+      REDIS_URL: redis://localhost:6379
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.8
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Build agent-service
+        run: pnpm --filter @kidbot/agent-service run build
+
+      - name: Test agent-service with Redis limiter smoke
+        env:
+          RATE_LIMIT_STORE: redis
+        run: pnpm --filter @kidbot/agent-service exec vitest run --coverage.enabled=false
+
+      - name: Build web-widget
+        run: pnpm --filter @kidbot/web-widget run build
+
+      - name: Test web-widget
+        run: pnpm --filter @kidbot/web-widget run test
+
+      - name: Build MCP server
+        run: pnpm --filter @kidbot/mcp-server run build
+
+      - name: Run MCP compatibility tests
+        run: pnpm --filter @kidbot/mcp-server run test:compat
+
+      - name: Run MCP auth/startup matrix
+        run: pnpm --filter @kidbot/mcp-server run test:auth-matrix

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ coverage/
 .vscode/
 .idea/
 *.log
+*.tsbuildinfo
 pnpm-lock.yaml

--- a/apps/agent-service/src/__tests__/rateLimit.test.ts
+++ b/apps/agent-service/src/__tests__/rateLimit.test.ts
@@ -103,3 +103,36 @@ describe('rate limit stores', () => {
     await expect(store.readiness()).resolves.toEqual({ mode: 'memory', ready: true });
   });
 });
+
+describe('redis rate limit store smoke', () => {
+  const redisUrl = process.env.REDIS_URL?.trim();
+  const itWithRedis = redisUrl ? it : it.skip;
+
+  itWithRedis('shares counts, ttl, reset, and readiness through Redis', async () => {
+    const store = createRateLimitStoreFromEnv({
+      RATE_LIMIT_STORE: 'redis',
+      REDIS_URL: redisUrl,
+    });
+    const key = `test:rate-limit:${Date.now()}:${Math.random()}`;
+
+    try {
+      await expect(store.readiness()).resolves.toMatchObject({
+        mode: 'redis',
+        ready: true,
+      });
+      await expect(store.increment(key, 5_000)).resolves.toMatchObject({
+        count: 1,
+      });
+      await expect(store.increment(key, 5_000)).resolves.toMatchObject({
+        count: 2,
+      });
+      await expect(store.ttl?.(key)).resolves.toBeGreaterThan(0);
+
+      await store.reset?.(key);
+      await expect(store.ttl?.(key)).resolves.toBe(-2);
+    } finally {
+      await store.reset?.(key);
+      await store.close?.();
+    }
+  });
+});

--- a/apps/agent-service/src/rateLimit.ts
+++ b/apps/agent-service/src/rateLimit.ts
@@ -25,6 +25,7 @@ export interface RateLimitStore {
   reset?(key: string): Promise<void>;
   ttl?(key: string): Promise<number>;
   readiness(): Promise<RateLimitStoreReadiness>;
+  close?(): Promise<void>;
 }
 
 export interface RateLimitStoreReadiness {
@@ -67,6 +68,9 @@ export const createMemoryRateLimitStore = (
     async readiness() {
       return { mode: 'memory', ready: true };
     },
+    async close() {
+      // Nothing to close for the in-process fallback.
+    },
   };
 };
 
@@ -107,6 +111,9 @@ export const createRedisRateLimitStore = (redisUrl: string): RateLimitStore => {
         const details = error instanceof Error ? error.message : 'Unknown Redis readiness error';
         return { mode: 'redis', ready: false, details: details.slice(0, 160) };
       }
+    },
+    async close() {
+      client.disconnect();
     },
   };
 };

--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -29,10 +29,14 @@ const renderStrokes = (canvas: HTMLCanvasElement, strokes: Stroke[]) => {
     if (stroke.points.length === 0) {
       continue;
     }
+    const start = stroke.points[0];
+    if (!start) {
+      continue;
+    }
     ctx.strokeStyle = stroke.color;
     ctx.lineWidth = stroke.size;
     ctx.beginPath();
-    ctx.moveTo(stroke.points[0].x, stroke.points[0].y);
+    ctx.moveTo(start.x, start.y);
     for (const point of stroke.points.slice(1)) {
       ctx.lineTo(point.x, point.y);
     }
@@ -53,7 +57,7 @@ export const ColoringBook = () => {
     loading,
     loadingMessage: 'Kidbot is drawing your coloring outline.',
     errorMessage: error,
-    readyMessage: outline ? 'Coloring outline ready.' : ''
+    readyMessage: outline ? 'Coloring outline ready.' : '',
   });
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -78,7 +82,7 @@ export const ColoringBook = () => {
     const rect = canvas.getBoundingClientRect();
     return {
       x: ((event.clientX - rect.left) / rect.width) * CANVAS_SIZE,
-      y: ((event.clientY - rect.top) / rect.height) * CANVAS_SIZE
+      y: ((event.clientY - rect.top) / rect.height) * CANVAS_SIZE,
     };
   };
 
@@ -140,7 +144,9 @@ export const ColoringBook = () => {
     setError(undefined);
     setOutline(undefined);
     try {
-      const result = (await window.openai?.callTool?.('coloring_outline', { scene, style })) as ColoringResponse | undefined;
+      const result = (await window.openai?.callTool?.('coloring_outline', { scene, style })) as
+        | ColoringResponse
+        | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }
@@ -173,7 +179,13 @@ export const ColoringBook = () => {
         <label htmlFor="scene">Scene</label>
         <input id="scene" value={scene} onChange={(event) => setScene(event.target.value)} />
         <label htmlFor="style">Style</label>
-        <select id="style" value={style ?? ''} onChange={(event) => setStyle(event.target.value ? (event.target.value as OutlineStyle) : undefined)}>
+        <select
+          id="style"
+          value={style ?? ''}
+          onChange={(event) =>
+            setStyle(event.target.value ? (event.target.value as OutlineStyle) : undefined)
+          }
+        >
           <option value="">Any</option>
           <option value="animals">Animals</option>
           <option value="space">Space</option>
@@ -199,7 +211,12 @@ export const ColoringBook = () => {
         </div>
         <aside className="tools">
           <label htmlFor="color">Color</label>
-          <input id="color" type="color" value={brushColor} onChange={(event) => setBrushColor(event.target.value)} />
+          <input
+            id="color"
+            type="color"
+            value={brushColor}
+            onChange={(event) => setBrushColor(event.target.value)}
+          />
           <label htmlFor="brush">Brush</label>
           <input
             id="brush"

--- a/apps/web-widget/src/utils/svgSanitizer.ts
+++ b/apps/web-widget/src/utils/svgSanitizer.ts
@@ -14,7 +14,7 @@ const ALLOWED_TAGS = new Set([
   'clipPath',
   'mask',
   'title',
-  'desc'
+  'desc',
 ]);
 
 const ALLOWED_ATTRS = new Set([
@@ -52,7 +52,7 @@ const ALLOWED_ATTRS = new Set([
   'role',
   'aria-hidden',
   'clip-path',
-  'mask'
+  'mask',
 ]);
 
 const DISALLOWED_PATTERN =
@@ -82,10 +82,10 @@ export const sanitizeSvgOutline = (value: string | undefined): string | undefine
   let match: RegExpExecArray | null = tagRegex.exec(trimmed);
   while (match) {
     const isClosing = match[1] === '/';
-    const tagName = match[2].toLowerCase();
+    const tagName = match[2]?.toLowerCase();
     const attrs = match[3] ?? '';
 
-    if (!ALLOWED_TAGS.has(tagName)) {
+    if (!tagName || !ALLOWED_TAGS.has(tagName)) {
       return undefined;
     }
 
@@ -93,11 +93,11 @@ export const sanitizeSvgOutline = (value: string | undefined): string | undefine
       const attrRegex = /([a-zA-Z_:][\w:.-]*)\s*=\s*(".*?"|'.*?'|[^\s"'>]+)/g;
       let attrMatch: RegExpExecArray | null = attrRegex.exec(attrs);
       while (attrMatch) {
-        const attrName = attrMatch[1].toLowerCase();
+        const attrName = attrMatch[1]?.toLowerCase();
         const attrValueRaw = attrMatch[2] ?? '';
         const attrValue = attrValueRaw.replace(/^['"]|['"]$/g, '').trim();
 
-        if (!ALLOWED_ATTRS.has(attrName)) {
+        if (!attrName || !ALLOWED_ATTRS.has(attrName)) {
           return undefined;
         }
 

--- a/apps/web-widget/tsconfig.json
+++ b/apps/web-widget/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "."
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],
   "references": []

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:all": "cross-env CI=1 pnpm -r --if-present run test && pnpm --filter mcp-server run test:compat"
   },
   "devDependencies": {
+    "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
     "concurrently": "^8.2.2",

--- a/scripts/run-typecheck.mjs
+++ b/scripts/run-typecheck.mjs
@@ -16,7 +16,7 @@ const isShim = hasLocalTsc
   : false;
 
 if (hasLocalTsc && !isShim) {
-  const result = spawnSync(tscBin, ['--noEmit'], { stdio: 'inherit' });
+  const result = spawnSync(tscBin, ['-b', '--noEmit'], { stdio: 'inherit' });
   process.exit(result.status ?? 0);
 }
 


### PR DESCRIPTION
## Summary

- add a GitHub Actions full-stack CI workflow for typecheck, agent-service build/tests, web-widget build/tests, and MCP build/compat/auth matrix
- provision Redis 7 as a CI service container and run agent-service tests with `RATE_LIMIT_STORE=redis`
- add a Redis-backed limiter smoke test covering readiness, shared counts, TTL, and reset
- make root typecheck use project references with `tsc -b --noEmit`

## Verification

- docker exec kidbot-redis redis-cli ping
- pnpm run typecheck
- pnpm --filter @kidbot/agent-service run build
- RATE_LIMIT_STORE=redis REDIS_URL=redis://localhost:6379 pnpm --filter @kidbot/agent-service exec vitest run --coverage.enabled=false
- pnpm --filter @kidbot/web-widget run build
- pnpm --filter @kidbot/web-widget run test
- pnpm --filter @kidbot/mcp-server run build
- pnpm --filter @kidbot/mcp-server run test:compat
- pnpm --filter @kidbot/mcp-server run test:auth-matrix