### PR TITLE
[codex] Opt CI actions into Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
     env:
       CI: '1'
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       REDIS_URL: redis://localhost:6379
 
     steps:


### PR DESCRIPTION
## Summary
- opt the CI job into GitHub's Node 24 JavaScript action runtime
- keep the project test runtime pinned to Node 20 via setup-node

## Verification
- git diff --check
- pnpm run typecheck