### PR TITLE
[codex] Update CI actions for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,22 @@ jobs:
 
     env:
       CI: '1'
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       REDIS_URL: redis://localhost:6379
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 8.15.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary
- update GitHub Actions dependencies to Node 24-native majors where available
- remove the temporary force-runtime flag
- disable setup-node's new package-manager auto-cache to keep install behavior unchanged

## Verification
- git diff --check
- pnpm run typecheck