### PR TITLE
[codex] add parent session safety controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ pnpm run smoke:secured-posture
 
 The smoke check starts local built services on ephemeral ports, verifies MCP can call agent-service with the shared token, and verifies unauthenticated, wrong-posture, and wrong-token calls fail.
 
+### Parent/Session Safety MVP
+
+The widget creates a local `sessionId`, uses the non-PII `profileId` value `local-default`, and stores the locked age band in ChatGPT widget state. Parent controls are gated by a 4-digit session PIN; the PIN is session-scoped widget state only and is not an account, authentication factor, persistent parent identity, or server-side access control.
+
+All child-facing tools use the locked widget age band. MCP and agent-service accept optional `sessionId`, `profileId`, and `ageBand` metadata for safe audit logs, default omitted `ageBand` to `7-9` behaviorally, and do not store profile or session data.
+
 ### Ngrok (optional)
 
 To expose the MCP server externally for ChatGPT Developer Mode connectors:

--- a/apps/agent-service/src/__tests__/contractIntegrity.test.ts
+++ b/apps/agent-service/src/__tests__/contractIntegrity.test.ts
@@ -38,12 +38,22 @@ describe('contract integrity', () => {
   it('keeps voice schema constraints aligned', async () => {
     const mcp = await loadMcpSchemas();
     const valid = { text: 'a', persona: 'robot' as const };
+    const validWithSession = {
+      ...valid,
+      ageBand: '7-9',
+      profileId: 'local-default',
+      sessionId: 'kb_session_abc123XYZ',
+    };
     const maxBoundary = { text: 'a'.repeat(280), persona: 'robot' as const };
     const tooLong = { text: 'a'.repeat(281), persona: 'robot' as const };
     const missingText = { persona: 'robot' as const };
+    const invalidSession = { ...valid, sessionId: 'kid name' };
+    const invalidProfile = { ...valid, profileId: 'ab' };
 
     expect(accepts(mcp.voiceInputSchema, valid)).toBe(true);
     expect(accepts(voiceRequestSchema, valid)).toBe(true);
+    expect(accepts(mcp.voiceInputSchema, validWithSession)).toBe(true);
+    expect(accepts(voiceRequestSchema, validWithSession)).toBe(true);
     expect(accepts(mcp.voiceInputSchema, maxBoundary)).toBe(true);
     expect(accepts(voiceRequestSchema, maxBoundary)).toBe(true);
     expect(accepts(mcp.voiceInputSchema, tooLong)).toBe(false);
@@ -54,12 +64,22 @@ describe('contract integrity', () => {
     expect(accepts(voiceRequestSchema, { ...valid, ageBand: '7-9' })).toBe(true);
     expect(accepts(mcp.voiceInputSchema, { ...valid, ageBand: '13-15' })).toBe(false);
     expect(accepts(voiceRequestSchema, { ...valid, ageBand: '13-15' })).toBe(false);
+    expect(accepts(mcp.voiceInputSchema, invalidSession)).toBe(false);
+    expect(accepts(voiceRequestSchema, invalidSession)).toBe(false);
+    expect(accepts(mcp.voiceInputSchema, invalidProfile)).toBe(false);
+    expect(accepts(voiceRequestSchema, invalidProfile)).toBe(false);
   });
 
   it('keeps story schema constraints aligned', async () => {
     const mcp = await loadMcpSchemas();
     const valid = { theme: 'Kind dragon story', panels: 4 };
     const validWithAge = { theme: 'Kind dragon story', panels: 4, ageBand: '7-9' };
+    const validWithSession = {
+      ...valid,
+      ageBand: '4-6',
+      profileId: 'local-default',
+      sessionId: 'kb_session_story123',
+    };
     const tooShortTheme = { theme: 'ab', panels: 4 };
     const tooManyPanels = { theme: 'Kind dragon story', panels: 9 };
     const tooFewPanels = { theme: 'Kind dragon story', panels: 1 };
@@ -69,6 +89,8 @@ describe('contract integrity', () => {
     expect(accepts(storyRequestSchema, valid)).toBe(true);
     expect(accepts(mcp.storyPanelsSchema, validWithAge)).toBe(true);
     expect(accepts(storyRequestSchema, validWithAge)).toBe(true);
+    expect(accepts(mcp.storyPanelsSchema, validWithSession)).toBe(true);
+    expect(accepts(storyRequestSchema, validWithSession)).toBe(true);
     expect(accepts(mcp.storyPanelsSchema, tooShortTheme)).toBe(false);
     expect(accepts(storyRequestSchema, tooShortTheme)).toBe(false);
     expect(accepts(mcp.storyPanelsSchema, tooManyPanels)).toBe(false);
@@ -83,6 +105,12 @@ describe('contract integrity', () => {
     const mcp = await loadMcpSchemas();
     const valid = { scene: 'space cat' };
     const validWithStyle = { scene: 'space cat', style: 'space' };
+    const validWithSession = {
+      ...valid,
+      ageBand: '10-12',
+      profileId: 'local-default',
+      sessionId: 'kb_session_color123',
+    };
     const invalidStyle = { scene: 'space cat', style: 'forest' };
     const tooShortScene = { scene: 'ab' };
 
@@ -90,6 +118,8 @@ describe('contract integrity', () => {
     expect(accepts(coloringRequestSchema, valid)).toBe(true);
     expect(accepts(mcp.coloringOutlineSchema, validWithStyle)).toBe(true);
     expect(accepts(coloringRequestSchema, validWithStyle)).toBe(true);
+    expect(accepts(mcp.coloringOutlineSchema, validWithSession)).toBe(true);
+    expect(accepts(coloringRequestSchema, validWithSession)).toBe(true);
     expect(accepts(mcp.coloringOutlineSchema, invalidStyle)).toBe(false);
     expect(accepts(coloringRequestSchema, invalidStyle)).toBe(false);
     expect(accepts(mcp.coloringOutlineSchema, tooShortScene)).toBe(false);
@@ -99,12 +129,20 @@ describe('contract integrity', () => {
   it('keeps science schema constraints aligned', async () => {
     const mcp = await loadMcpSchemas();
     const valid = { topic: 'buoyancy' };
+    const validWithSession = {
+      ...valid,
+      ageBand: '7-9',
+      profileId: 'local-default',
+      sessionId: 'kb_session_science123',
+    };
     const tooShortTopic = { topic: 'ab' };
     const validWithAge = { topic: 'buoyancy', ageBand: '10-12' };
     const invalidAge = { topic: 'buoyancy', ageBand: '13-15' };
 
     expect(accepts(mcp.scienceSimSchema, valid)).toBe(true);
     expect(accepts(scienceRequestSchema, valid)).toBe(true);
+    expect(accepts(mcp.scienceSimSchema, validWithSession)).toBe(true);
+    expect(accepts(scienceRequestSchema, validWithSession)).toBe(true);
     expect(accepts(mcp.scienceSimSchema, tooShortTopic)).toBe(false);
     expect(accepts(scienceRequestSchema, tooShortTopic)).toBe(false);
     expect(accepts(mcp.scienceSimSchema, validWithAge)).toBe(true);

--- a/apps/agent-service/src/__tests__/serviceAuthBoundary.test.ts
+++ b/apps/agent-service/src/__tests__/serviceAuthBoundary.test.ts
@@ -375,4 +375,50 @@ describe('service auth boundary', () => {
       },
     );
   });
+
+  it('logs safe session audit metadata without PIN values', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      await withEnv(
+        {
+          NODE_ENV: 'test',
+          FALLBACK_WIDGET: '0',
+          KIDBOT_LOCAL_DEV: undefined,
+          AGENT_SERVICE_TOKEN: 'test-service-token',
+          OPENAI_API_KEY: undefined,
+        },
+        async () => {
+          const mod = await import('../index.js');
+          await withServer(mod.app, async (baseUrl) => {
+            const response = await fetch(`${baseUrl}/voice`, {
+              method: 'POST',
+              headers: {
+                Authorization: 'Bearer test-service-token',
+                'x-kidbot-startup-posture': 'secured',
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                text: 'Tell me a cheerful moon fact.',
+                persona: 'robot',
+                ageBand: '4-6',
+                profileId: 'local-default',
+                sessionId: 'kb_session_audit123',
+                parentPin: '1234',
+              }),
+            });
+
+            expect(response.status).toBe(200);
+          });
+        },
+      );
+
+      const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logs).toContain('"sessionId":"kb_session_audit123"');
+      expect(logs).toContain('"profileId":"local-default"');
+      expect(logs).toContain('"ageBand":"4-6"');
+      expect(logs).not.toContain('1234');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/apps/agent-service/src/index.ts
+++ b/apps/agent-service/src/index.ts
@@ -23,6 +23,7 @@ import { createRateLimiter, createRateLimitStoreFromEnv } from './rateLimit.js';
 import { safeFallbackSvg, validateColoringSvg } from './svgSafety.js';
 import {
   coloringRequestSchema,
+  defaultAgeBand,
   scienceRequestSchema,
   storyRequestSchema,
   voiceRequestSchema,
@@ -113,6 +114,18 @@ const withValidation = <T>(
     res.locals.correlationId = id;
     try {
       const parsed = schema.parse(req.body);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const metadata = parsed as {
+          ageBand?: unknown;
+          profileId?: unknown;
+          sessionId?: unknown;
+        };
+        res.locals.sessionId =
+          typeof metadata.sessionId === 'string' ? metadata.sessionId : undefined;
+        res.locals.profileId =
+          typeof metadata.profileId === 'string' ? metadata.profileId : undefined;
+        res.locals.ageBand = typeof metadata.ageBand === 'string' ? metadata.ageBand : defaultAgeBand;
+      }
       const data = await handler(parsed);
       if (!data || typeof data !== 'object' || Array.isArray(data)) {
         throw new Error('Handler must return an object payload.');
@@ -329,6 +342,9 @@ app.use((req, res, next) => {
       route: req.path,
       status: res.statusCode,
       latencyMs: Date.now() - startedAt,
+      sessionId: res.locals.sessionId as string | undefined,
+      profileId: res.locals.profileId as string | undefined,
+      ageBand: res.locals.ageBand as string | undefined,
       source: res.locals.source as string | undefined,
       blocked: res.locals.blocked as boolean | undefined,
       inputLength,

--- a/apps/agent-service/src/types.ts
+++ b/apps/agent-service/src/types.ts
@@ -6,33 +6,38 @@ export type AgeBand = (typeof ageBandValues)[number];
 export const personaValues = ['robot', 'fairy', 'explorer'] as const;
 export type Persona = (typeof personaValues)[number];
 
+export const defaultAgeBand: AgeBand = '7-9';
+
+const sessionMetadataSchema = z.object({
+  sessionId: z.string().regex(/^kb_session_[A-Za-z0-9_-]{8,80}$/).optional(),
+  profileId: z.string().regex(/^[A-Za-z0-9_-]{3,64}$/).optional(),
+  ageBand: z.enum(ageBandValues).optional()
+});
+
 export const voiceRequestSchema = z.object({
   text: z.string().min(1).max(280),
   persona: z.enum(personaValues),
-  ageBand: z.enum(ageBandValues).optional()
-});
+}).merge(sessionMetadataSchema);
 
 export type VoiceRequest = z.infer<typeof voiceRequestSchema>;
 
 export const storyRequestSchema = z.object({
   theme: z.string().min(3).max(120),
   panels: z.number().int().min(2).max(8),
-  ageBand: z.enum(ageBandValues).optional()
-});
+}).merge(sessionMetadataSchema);
 
 export type StoryRequest = z.infer<typeof storyRequestSchema>;
 
 export const coloringRequestSchema = z.object({
   scene: z.string().min(3).max(120),
   style: z.enum(['animals', 'space', 'underwater']).optional()
-});
+}).merge(sessionMetadataSchema);
 
 export type ColoringRequest = z.infer<typeof coloringRequestSchema>;
 
 export const scienceRequestSchema = z.object({
   topic: z.string().min(3).max(120),
-  ageBand: z.enum(ageBandValues).optional()
-});
+}).merge(sessionMetadataSchema);
 
 export type ScienceRequest = z.infer<typeof scienceRequestSchema>;
 

--- a/apps/mcp-server/src/schema.ts
+++ b/apps/mcp-server/src/schema.ts
@@ -3,24 +3,27 @@ import { z } from 'zod';
 export const ageBandSchema = z.enum(['4-6', '7-9', '10-12']);
 export const personaSchema = z.enum(['robot', 'fairy', 'explorer']);
 
+const sessionMetadataSchema = z.object({
+  sessionId: z.string().regex(/^kb_session_[A-Za-z0-9_-]{8,80}$/).optional(),
+  profileId: z.string().regex(/^[A-Za-z0-9_-]{3,64}$/).optional(),
+  ageBand: ageBandSchema.optional()
+});
+
 export const voiceInputSchema = z.object({
   text: z.string().min(1).max(280),
   persona: personaSchema,
-  ageBand: ageBandSchema.optional()
-});
+}).merge(sessionMetadataSchema);
 
 export const storyPanelsSchema = z.object({
   theme: z.string().min(3).max(120),
   panels: z.number().int().min(2).max(8),
-  ageBand: ageBandSchema.optional()
-});
+}).merge(sessionMetadataSchema);
 
 export const coloringOutlineSchema = z.object({
   scene: z.string().min(3).max(120),
   style: z.enum(['animals', 'space', 'underwater']).optional()
-});
+}).merge(sessionMetadataSchema);
 
 export const scienceSimSchema = z.object({
   topic: z.string().min(3).max(120),
-  ageBand: ageBandSchema.optional()
-});
+}).merge(sessionMetadataSchema);

--- a/apps/mcp-server/test/auth-startup-matrix.test.mjs
+++ b/apps/mcp-server/test/auth-startup-matrix.test.mjs
@@ -427,3 +427,81 @@ test('mcp surfaces provider 503 as degraded content instead of a safety block', 
     await closeServer(fakeAgent);
   }
 });
+
+test('mcp forwards session metadata to agent-service', async () => {
+  const token = strongToken();
+  const agentPort = await getFreePort();
+  const mcpPort = await getFreePort();
+  const mcpBaseUrl = `http://localhost:${mcpPort}`;
+  let forwardedBody;
+
+  const fakeAgent = createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/voice') {
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        forwardedBody = JSON.parse(body);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            blocked: false,
+            persona: 'robot',
+            text: 'Forwarding check ready.',
+          }),
+        );
+      });
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  });
+
+  await listen(fakeAgent, agentPort);
+
+  const mcp = spawnProcess(mcpEntry, {
+    AGENT_PORT: String(agentPort),
+    AGENT_SERVICE_TOKEN: token,
+    FALLBACK_WIDGET: '0',
+    MCP_PORT: String(mcpPort),
+  });
+
+  try {
+    await waitForMcpHealth(mcpBaseUrl);
+
+    const response = await callMcp(mcpBaseUrl, {
+      jsonrpc: '2.0',
+      id: 105,
+      method: 'tools/call',
+      params: {
+        name: 'voice_chat',
+        arguments: {
+          text: 'Tell me a moon fact',
+          persona: 'robot',
+          ageBand: '4-6',
+          profileId: 'local-default',
+          sessionId: 'kb_session_forward123',
+        },
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(
+      {
+        ageBand: forwardedBody.ageBand,
+        profileId: forwardedBody.profileId,
+        sessionId: forwardedBody.sessionId,
+      },
+      {
+        ageBand: '4-6',
+        profileId: 'local-default',
+        sessionId: 'kb_session_forward123',
+      },
+    );
+  } finally {
+    stopProcess(mcp);
+    await closeServer(fakeAgent);
+  }
+});

--- a/apps/web-widget/src/App.sessionState.test.tsx
+++ b/apps/web-widget/src/App.sessionState.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from './main.js';
+
+describe('App parent/session safety controls', () => {
+  const callTool = vi.fn();
+  const setWidgetState = vi.fn();
+  const requestDisplayMode = vi.fn();
+  let savedState: Record<string, unknown> | undefined;
+
+  beforeEach(() => {
+    callTool.mockReset();
+    setWidgetState.mockReset();
+    requestDisplayMode.mockReset();
+    savedState = undefined;
+    setWidgetState.mockImplementation((state: Record<string, unknown>) => {
+      savedState = state;
+    });
+    (window as { openai?: unknown }).openai = {
+      callTool,
+      getWidgetState: () => savedState,
+      requestDisplayMode,
+      setWidgetState,
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as { openai?: unknown }).openai;
+  });
+
+  it('creates and persists a local session state', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(setWidgetState).toHaveBeenCalled();
+    });
+
+    expect(savedState?.sessionId).toMatch(/^kb_session_/);
+    expect(savedState?.profileId).toBe('local-default');
+    expect(savedState?.ageBand).toBe('7-9');
+    expect(savedState?.parentModeUnlocked).toBe(false);
+  });
+
+  it('uses a session PIN to unlock and change the locked age band', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('Create parent PIN'), { target: { value: '1234' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Set Parent PIN' }));
+
+    await screen.findByText('Parent controls unlocked.');
+    fireEvent.change(screen.getByLabelText('Locked age'), { target: { value: '10-12' } });
+
+    await waitFor(() => {
+      expect(savedState?.ageBand).toBe('10-12');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Lock Parent Controls' }));
+    fireEvent.change(screen.getByLabelText('Parent PIN'), { target: { value: '9999' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Unlock Parent Controls' }));
+
+    await screen.findByText('PIN did not match.');
+    expect(screen.queryByLabelText('Locked age')).toBeNull();
+  });
+
+  it('sends locked session metadata to child tool calls', async () => {
+    callTool.mockResolvedValue({
+      blocked: false,
+      persona: 'robot',
+      text: 'A happy moon fact.',
+    });
+    savedState = {
+      ageBand: '4-6',
+      parentPin: '1234',
+      parentPinSet: true,
+      profileId: 'local-default',
+      sessionId: 'kb_session_existing123',
+      tab: 'voice',
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(callTool).toHaveBeenCalledWith(
+        'voice_chat',
+        expect.objectContaining({
+          ageBand: '4-6',
+          profileId: 'local-default',
+          sessionId: 'kb_session_existing123',
+        }),
+      );
+    });
+    expect(screen.queryByLabelText('Age')).toBeNull();
+  });
+});

--- a/apps/web-widget/src/components/ColoringBook.tsx
+++ b/apps/web-widget/src/components/ColoringBook.tsx
@@ -8,6 +8,7 @@ import {
   errorMessage,
   unavailableMessageFromError,
 } from '../utils/degradation.js';
+import { defaultSessionContext, type SessionContext } from '../utils/sessionContext.js';
 
 type OutlineStyle = 'animals' | 'space' | 'underwater' | undefined;
 
@@ -50,7 +51,11 @@ const renderStrokes = (canvas: HTMLCanvasElement, strokes: Stroke[]) => {
   }
 };
 
-export const ColoringBook = () => {
+interface ColoringBookProps {
+  sessionContext?: SessionContext;
+}
+
+export const ColoringBook = ({ sessionContext = defaultSessionContext }: ColoringBookProps) => {
   const [scene, setScene] = useState('Joyful treehouse afternoon');
   const [style, setStyle] = useState<OutlineStyle>(undefined);
   const [outline, setOutline] = useState<string | undefined>();
@@ -71,10 +76,6 @@ export const ColoringBook = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const drawingRef = useRef<boolean>(false);
   const currentStrokeRef = useRef<Stroke | null>(null);
-
-  useEffect(() => {
-    window.openai?.setWidgetState?.({ tab: 'coloring', scene, style, brushColor, brushSize });
-  }, [scene, style, brushColor, brushSize]);
 
   useEffect(() => {
     if (canvasRef.current) {
@@ -153,9 +154,11 @@ export const ColoringBook = () => {
     setUnavailable(undefined);
     setOutline(undefined);
     try {
-      const result = (await window.openai?.callTool?.('coloring_outline', { scene, style })) as
-        | ColoringResponse
-        | undefined;
+      const result = (await window.openai?.callTool?.('coloring_outline', {
+        ...sessionContext,
+        scene,
+        style,
+      })) as ColoringResponse | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }

--- a/apps/web-widget/src/components/ComicBoard.tsx
+++ b/apps/web-widget/src/components/ComicBoard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
 import {
@@ -6,6 +6,7 @@ import {
   errorMessage,
   unavailableMessageFromError,
 } from '../utils/degradation.js';
+import { defaultSessionContext, type SessionContext } from '../utils/sessionContext.js';
 
 interface StoryPanel {
   title: string;
@@ -22,10 +23,13 @@ interface StoryResponse {
   panels?: StoryPanel[];
 }
 
-export const ComicBoard = () => {
+interface ComicBoardProps {
+  sessionContext?: SessionContext;
+}
+
+export const ComicBoard = ({ sessionContext = defaultSessionContext }: ComicBoardProps) => {
   const [theme, setTheme] = useState('A brave turtle shares snacks');
   const [panelCount, setPanelCount] = useState(4);
-  const [ageBand, setAgeBand] = useState<'4-6' | '7-9' | '10-12'>('7-9');
   const [panels, setPanels] = useState<StoryPanel[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
@@ -38,10 +42,6 @@ export const ComicBoard = () => {
     readyMessage: panels.length > 0 ? `Planned ${panels.length} panels.` : '',
   });
 
-  useEffect(() => {
-    window.openai?.setWidgetState?.({ tab: 'comics', theme, panelCount, ageBand });
-  }, [theme, panelCount, ageBand]);
-
   const handlePlan = async () => {
     setLoading(true);
     setError(undefined);
@@ -49,9 +49,9 @@ export const ComicBoard = () => {
     setPanels([]);
     try {
       const result = (await window.openai?.callTool?.('story_panels', {
+        ...sessionContext,
         theme,
         panels: panelCount,
-        ageBand,
       })) as StoryResponse | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
@@ -94,16 +94,7 @@ export const ComicBoard = () => {
           value={panelCount}
           onChange={(event) => setPanelCount(Number(event.target.value))}
         />
-        <label htmlFor="panel-age">Age</label>
-        <select
-          id="panel-age"
-          value={ageBand}
-          onChange={(event) => setAgeBand(event.target.value as '4-6' | '7-9' | '10-12')}
-        >
-          <option value="4-6">Ages 4-6</option>
-          <option value="7-9">Ages 7-9</option>
-          <option value="10-12">Ages 10-12</option>
-        </select>
+        <span className="locked-age">Age: {sessionContext.ageBand}</span>
         <button type="button" onClick={handlePlan} disabled={loading}>
           {loading ? 'Planning...' : 'Plan Panels'}
         </button>

--- a/apps/web-widget/src/components/ScienceLab.tsx
+++ b/apps/web-widget/src/components/ScienceLab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
 import {
@@ -6,8 +6,7 @@ import {
   errorMessage,
   unavailableMessageFromError,
 } from '../utils/degradation.js';
-
-type AgeBand = '4-6' | '7-9' | '10-12';
+import { defaultSessionContext, type SessionContext } from '../utils/sessionContext.js';
 
 interface ScienceResponse {
   blocked: boolean;
@@ -24,9 +23,12 @@ interface ScienceResponse {
 
 const topics = ['Buoyancy', 'Magnetism', 'Rainbows', 'Plant Growth'];
 
-export const ScienceLab = () => {
+interface ScienceLabProps {
+  sessionContext?: SessionContext;
+}
+
+export const ScienceLab = ({ sessionContext = defaultSessionContext }: ScienceLabProps) => {
   const [topic, setTopic] = useState('Buoyancy');
-  const [ageBand, setAgeBand] = useState<AgeBand>('7-9');
   const [plan, setPlan] = useState<ScienceResponse | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [unavailable, setUnavailable] = useState<string | undefined>();
@@ -41,10 +43,6 @@ export const ScienceLab = () => {
     readyMessage: plan && !plan.blocked ? `${plan.title ?? 'Experiment'} ready.` : '',
   });
 
-  useEffect(() => {
-    window.openai?.setWidgetState?.({ tab: 'science', topic, ageBand });
-  }, [topic, ageBand]);
-
   const fetchPlan = async () => {
     setLoading(true);
     setError(undefined);
@@ -53,9 +51,10 @@ export const ScienceLab = () => {
     setShowExplanation(false);
     setSelectedChoice(undefined);
     try {
-      const result = (await window.openai?.callTool?.('science_sim', { topic, ageBand })) as
-        | ScienceResponse
-        | undefined;
+      const result = (await window.openai?.callTool?.('science_sim', {
+        ...sessionContext,
+        topic,
+      })) as ScienceResponse | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }
@@ -94,16 +93,7 @@ export const ScienceLab = () => {
             </option>
           ))}
         </select>
-        <label htmlFor="science-age">Age</label>
-        <select
-          id="science-age"
-          value={ageBand}
-          onChange={(event) => setAgeBand(event.target.value as AgeBand)}
-        >
-          <option value="4-6">Ages 4-6</option>
-          <option value="7-9">Ages 7-9</option>
-          <option value="10-12">Ages 10-12</option>
-        </select>
+        <span className="locked-age">Age: {sessionContext.ageBand}</span>
         <button type="button" onClick={fetchPlan} disabled={loading}>
           {loading ? 'Mixing...' : 'Generate Experiment'}
         </button>

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
 import {
@@ -6,9 +6,9 @@ import {
   errorMessage,
   unavailableMessageFromError,
 } from '../utils/degradation.js';
+import { defaultSessionContext, type SessionContext } from '../utils/sessionContext.js';
 
 type Persona = 'robot' | 'fairy' | 'explorer';
-type AgeBand = '4-6' | '7-9' | '10-12';
 
 interface VoiceResult {
   blocked: boolean;
@@ -25,12 +25,6 @@ const personas: Array<{ key: Persona; label: string }> = [
   { key: 'explorer', label: 'Explorer Pal' },
 ];
 
-const ageBands: Array<{ key: AgeBand; label: string }> = [
-  { key: '4-6', label: 'Ages 4-6' },
-  { key: '7-9', label: 'Ages 7-9' },
-  { key: '10-12', label: 'Ages 10-12' },
-];
-
 const speakText = (text: string) => {
   if (typeof window === 'undefined' || typeof window.speechSynthesis === 'undefined') {
     return;
@@ -41,9 +35,12 @@ const speakText = (text: string) => {
   window.speechSynthesis.speak(utterance);
 };
 
-export const VoiceBar = () => {
+interface VoiceBarProps {
+  sessionContext?: SessionContext;
+}
+
+export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarProps) => {
   const [persona, setPersona] = useState<Persona>('robot');
-  const [ageBand, setAgeBand] = useState<AgeBand>('7-9');
   const [text, setText] = useState('Tell me a cheerful space fact!');
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<VoiceResult | undefined>();
@@ -60,10 +57,6 @@ export const VoiceBar = () => {
     readyMessage: response?.text ? `${response.persona ?? 'Kidbot'} reply ready.` : '',
   });
 
-  useEffect(() => {
-    window.openai?.setWidgetState?.({ tab: 'voice', persona, ageBand, text });
-  }, [persona, ageBand, text]);
-
   const handleSpeak = async () => {
     if (!text.trim()) {
       setError('Please share what you would like to talk about.');
@@ -75,9 +68,11 @@ export const VoiceBar = () => {
     setUnavailable(undefined);
     setResponse(undefined);
     try {
-      const result = (await window.openai?.callTool?.('voice_chat', { text, persona, ageBand })) as
-        | VoiceResult
-        | undefined;
+      const result = (await window.openai?.callTool?.('voice_chat', {
+        ...sessionContext,
+        text,
+        persona,
+      })) as VoiceResult | undefined;
       if (!result) {
         throw new Error('Widget bridge unavailable.');
       }
@@ -120,18 +115,7 @@ export const VoiceBar = () => {
             </option>
           ))}
         </select>
-        <label htmlFor="ageBand">Age</label>
-        <select
-          id="ageBand"
-          value={ageBand}
-          onChange={(event) => setAgeBand(event.target.value as AgeBand)}
-        >
-          {ageBands.map((option) => (
-            <option key={option.key} value={option.key}>
-              {option.label}
-            </option>
-          ))}
-        </select>
+        <span className="locked-age">Age: {sessionContext.ageBand}</span>
       </div>
       <textarea
         value={text}

--- a/apps/web-widget/src/main.tsx
+++ b/apps/web-widget/src/main.tsx
@@ -4,6 +4,13 @@ import { ColoringBook } from './components/ColoringBook.js';
 import { ComicBoard } from './components/ComicBoard.js';
 import { ScienceLab } from './components/ScienceLab.js';
 import { VoiceBar } from './components/VoiceBar.js';
+import {
+  ageBandOptions,
+  createSessionId,
+  isAgeBand,
+  type AgeBand,
+  type SessionContext,
+} from './utils/sessionContext.js';
 import './styles.css';
 
 type TabKey = 'voice' | 'comics' | 'coloring' | 'science';
@@ -14,6 +21,18 @@ const tabs: Array<{ key: TabKey; label: string }> = [
   { key: 'coloring', label: 'Coloring' },
   { key: 'science', label: 'Science Lab' }
 ];
+
+const profileId = 'local-default';
+
+interface WidgetSessionState {
+  ageBand: AgeBand;
+  parentModeUnlocked: boolean;
+  parentPin?: string;
+  parentPinSet: boolean;
+  profileId: string;
+  sessionId: string;
+  tab: TabKey;
+}
 
 declare global {
   interface Window {
@@ -26,32 +45,148 @@ declare global {
   }
 }
 
-const App = () => {
+const isTabKey = (value: unknown): value is TabKey =>
+  typeof value === 'string' && tabs.some((tab) => tab.key === value);
+
+const readInitialState = (): WidgetSessionState => {
+  const saved = window.openai?.getWidgetState?.();
+  const savedSessionId = typeof saved?.sessionId === 'string' ? saved.sessionId : undefined;
+  const savedPin = typeof saved?.parentPin === 'string' ? saved.parentPin : undefined;
+  return {
+    ageBand: isAgeBand(saved?.ageBand) ? saved.ageBand : '7-9',
+    parentModeUnlocked: false,
+    parentPin: savedPin,
+    parentPinSet: Boolean(savedPin || saved?.parentPinSet),
+    profileId,
+    sessionId: savedSessionId ?? createSessionId(),
+    tab: isTabKey(saved?.tab) ? saved.tab : 'voice',
+  };
+};
+
+export const App = () => {
+  const [sessionState, setSessionState] = useState<WidgetSessionState>(() => readInitialState());
   const [activeTab, setActiveTab] = useState<TabKey>('voice');
+  const [pinInput, setPinInput] = useState('');
+  const [pinMessage, setPinMessage] = useState<string | undefined>();
+  const sessionContext: SessionContext = {
+    ageBand: sessionState.ageBand,
+    profileId: sessionState.profileId,
+    sessionId: sessionState.sessionId,
+  };
 
   useEffect(() => {
-    const saved = window.openai?.getWidgetState?.();
-    if (saved && typeof saved.tab === 'string' && tabs.some((tab) => tab.key === saved.tab)) {
-      setActiveTab(saved.tab as TabKey);
-    }
+    setActiveTab(sessionState.tab);
     window.openai?.requestDisplayMode?.({ mode: 'fullscreen' });
-  }, []);
+  }, [sessionState.tab]);
 
   useEffect(() => {
-    window.openai?.setWidgetState?.({ tab: activeTab });
-  }, [activeTab]);
+    window.openai?.setWidgetState?.({
+      ageBand: sessionState.ageBand,
+      parentModeUnlocked: sessionState.parentModeUnlocked,
+      parentPin: sessionState.parentPin,
+      parentPinSet: sessionState.parentPinSet,
+      profileId: sessionState.profileId,
+      sessionId: sessionState.sessionId,
+      tab: activeTab,
+    });
+  }, [activeTab, sessionState]);
+
+  const handleParentSubmit = () => {
+    if (!/^\d{4}$/.test(pinInput)) {
+      setPinMessage('Enter a 4-digit PIN.');
+      return;
+    }
+
+    if (!sessionState.parentPinSet) {
+      setSessionState((prev) => ({
+        ...prev,
+        parentModeUnlocked: true,
+        parentPin: pinInput,
+        parentPinSet: true,
+      }));
+      setPinInput('');
+      setPinMessage('Parent controls unlocked.');
+      return;
+    }
+
+    if (pinInput !== sessionState.parentPin) {
+      setPinMessage('PIN did not match.');
+      return;
+    }
+
+    setSessionState((prev) => ({ ...prev, parentModeUnlocked: true }));
+    setPinInput('');
+    setPinMessage('Parent controls unlocked.');
+  };
+
+  const lockParentMode = () => {
+    setSessionState((prev) => ({ ...prev, parentModeUnlocked: false }));
+    setPinInput('');
+    setPinMessage(undefined);
+  };
+
+  const updateAgeBand = (ageBand: AgeBand) => {
+    setSessionState((prev) => ({ ...prev, ageBand }));
+  };
 
   return (
     <div className="kidbot-app">
       <header className="kidbot-header">
         <h1>Kidbot Play Studio</h1>
+        <section className="parent-controls" aria-label="Parent controls">
+          <div className="session-summary">
+            <span>Age: {sessionState.ageBand}</span>
+            <span>Profile: {sessionState.profileId}</span>
+          </div>
+          {sessionState.parentModeUnlocked ? (
+            <div className="control-row">
+              <label htmlFor="locked-age">Locked age</label>
+              <select
+                id="locked-age"
+                value={sessionState.ageBand}
+                onChange={(event) => updateAgeBand(event.target.value as AgeBand)}
+              >
+                {ageBandOptions.map((option) => (
+                  <option key={option.key} value={option.key}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <button type="button" onClick={lockParentMode}>
+                Lock Parent Controls
+              </button>
+            </div>
+          ) : (
+            <div className="control-row">
+              <label htmlFor="parent-pin">
+                {sessionState.parentPinSet ? 'Parent PIN' : 'Create parent PIN'}
+              </label>
+              <input
+                id="parent-pin"
+                inputMode="numeric"
+                maxLength={4}
+                pattern="[0-9]*"
+                type="password"
+                value={pinInput}
+                onChange={(event) => setPinInput(event.target.value.replace(/\D/g, '').slice(0, 4))}
+              />
+              <button type="button" onClick={handleParentSubmit}>
+                {sessionState.parentPinSet ? 'Unlock Parent Controls' : 'Set Parent PIN'}
+              </button>
+            </div>
+          )}
+          {pinMessage && <p className="parent-message">{pinMessage}</p>}
+        </section>
         <nav>
           {tabs.map((tab) => (
             <button
               key={tab.key}
               className={activeTab === tab.key ? 'active' : ''}
               type="button"
-              onClick={() => setActiveTab(tab.key)}
+              onClick={() => {
+                setActiveTab(tab.key);
+                setSessionState((prev) => ({ ...prev, tab: tab.key }));
+              }}
             >
               {tab.label}
             </button>
@@ -59,10 +194,10 @@ const App = () => {
         </nav>
       </header>
       <main>
-        {activeTab === 'voice' && <VoiceBar />}
-        {activeTab === 'comics' && <ComicBoard />}
-        {activeTab === 'coloring' && <ColoringBook />}
-        {activeTab === 'science' && <ScienceLab />}
+        {activeTab === 'voice' && <VoiceBar sessionContext={sessionContext} />}
+        {activeTab === 'comics' && <ComicBoard sessionContext={sessionContext} />}
+        {activeTab === 'coloring' && <ColoringBook sessionContext={sessionContext} />}
+        {activeTab === 'science' && <ScienceLab sessionContext={sessionContext} />}
       </main>
     </div>
   );

--- a/apps/web-widget/src/styles.css
+++ b/apps/web-widget/src/styles.css
@@ -38,6 +38,41 @@ body {
   justify-content: center;
 }
 
+.parent-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+  width: min(100%, 720px);
+  padding: 0.75rem;
+  border: 2px solid #bae6fd;
+  border-radius: 16px;
+  background: #ffffffcc;
+}
+
+.session-summary {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  color: #075985;
+  font-weight: 700;
+}
+
+.parent-message {
+  margin: 0;
+  color: #334155;
+  font-weight: 600;
+}
+
+.locked-age {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #075985;
+  font-weight: 700;
+}
+
 .kidbot-header button {
   border: none;
   padding: 0.6rem 1rem;

--- a/apps/web-widget/src/utils/sessionContext.ts
+++ b/apps/web-widget/src/utils/sessionContext.ts
@@ -1,0 +1,30 @@
+export type AgeBand = '4-6' | '7-9' | '10-12';
+
+export interface SessionContext {
+  ageBand: AgeBand;
+  profileId: string;
+  sessionId: string;
+}
+
+export const defaultSessionContext: SessionContext = {
+  ageBand: '7-9',
+  profileId: 'local-default',
+  sessionId: 'kb_session_localdefault',
+};
+
+export const ageBandOptions: Array<{ key: AgeBand; label: string }> = [
+  { key: '4-6', label: 'Ages 4-6' },
+  { key: '7-9', label: 'Ages 7-9' },
+  { key: '10-12', label: 'Ages 10-12' },
+];
+
+export const isAgeBand = (value: unknown): value is AgeBand =>
+  value === '4-6' || value === '7-9' || value === '10-12';
+
+export const createSessionId = () => {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && 'randomUUID' in cryptoApi) {
+    return `kb_session_${cryptoApi.randomUUID().replace(/-/g, '')}`;
+  }
+  return `kb_session_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+};


### PR DESCRIPTION
## Summary
- add widget-scoped session/profile state with a parent PIN gate and locked age band
- forward optional sessionId/profileId/ageBand metadata through widget -> MCP -> agent-service
- log safe audit metadata in agent-service without PIN/token/prompt values
- document the MVP boundary as local/session safety, not persistent parent auth

## Verification
- pnpm run typecheck
- pnpm --filter @kidbot/agent-service run build
- pnpm --filter @kidbot/mcp-server run build
- pnpm --filter @kidbot/web-widget run build
- pnpm --filter @kidbot/agent-service exec vitest run --coverage.enabled=false
- pnpm --filter @kidbot/web-widget run test
- pnpm --filter @kidbot/mcp-server run test:compat
- pnpm --filter @kidbot/mcp-server run test:auth-matrix
- pnpm run smoke:secured-posture
- pnpm run lint
- pnpm run test:all
- git diff --check

Note: `pnpm run test` still falls back to smoke-only because its Node child process cannot find pnpm in this local shell; `pnpm run test:all` executed the package Vitest suites and MCP compat test.
