### PR TITLE
[codex] add railway split service agent url config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ OPENAI_API_KEY=
 AGENT_SERVICE_TOKEN=
 MCP_PORT=3000
 AGENT_PORT=4505
+# Optional production override for split service deploys, for example Railway.
+# Defaults to http://localhost:${AGENT_PORT}
+AGENT_BASE_URL=
 FALLBACK_WIDGET=0
 KIDBOT_LOCAL_DEV=0
 RATE_LIMIT_STORE=redis

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ OPENAI_API_KEY=
 AGENT_SERVICE_TOKEN=
 MCP_PORT=3000
 AGENT_PORT=4505
+AGENT_BASE_URL=
 FALLBACK_WIDGET=0
 KIDBOT_LOCAL_DEV=0
 RATE_LIMIT_STORE=redis
@@ -54,6 +55,8 @@ openssl rand -base64 48
 ```
 
 When `FALLBACK_WIDGET` is not `1` (secured posture), both `agent-service` and `mcp-server` must receive the same `AGENT_SERVICE_TOKEN`. Direct calls to `agent-service` must include both `Authorization: Bearer <AGENT_SERVICE_TOKEN>` and `x-kidbot-startup-posture: secured`. The MCP server sets both automatically for tool calls. Outside `NODE_ENV=test`, secured startup fails if the token is missing or shorter than 32 characters.
+
+For split-service production deploys, set `AGENT_BASE_URL` on MCP to the agent-service origin. If omitted, MCP keeps the local default `http://localhost:${AGENT_PORT}`.
 
 Start self-hosted Redis locally with:
 
@@ -106,6 +109,49 @@ pnpm run smoke:parent-store-remote
 The remote smoke uses only the deployed MCP URL. It never reads, sends, or logs `PARENT_AUTH_SECRET`; it proves secret-backed startup indirectly through Redis health plus successful parent profile create/update/history behavior. A degraded child-tool response is acceptable if it is recorded as safe metadata rather than treated as a safety block.
 
 GitHub Actions also includes the manual `Production Parent Store Smoke` workflow. Store `KIDBOT_REMOTE_MCP_URL` as a protected production environment secret before running it.
+
+### Railway Production Deploy
+
+Railway is the first recommended production host for Kidbot because the repo currently runs long-lived Node/Express services plus Redis.
+
+Create one Railway project with:
+
+- `kidbot-agent-service`: build `pnpm install --no-frozen-lockfile && pnpm --filter @kidbot/agent-service run build`; start `pnpm --filter @kidbot/agent-service run start`.
+- `kidbot-mcp-server`: build `pnpm install --no-frozen-lockfile && pnpm --filter @kidbot/mcp-server run build`; start `pnpm --filter @kidbot/mcp-server run start`.
+- `redis`: Railway Redis service/template.
+
+Set shared Railway env:
+
+```env
+NODE_ENV=production
+FALLBACK_WIDGET=0
+KIDBOT_LOCAL_DEV=0
+REDIS_URL=<Railway Redis private URL>
+```
+
+Set agent-service env:
+
+```env
+PORT=<Railway assigned port>
+AGENT_SERVICE_TOKEN=<same high-entropy service token as MCP>
+OPENAI_API_KEY=<production OpenAI key>
+RATE_LIMIT_STORE=redis
+PROVIDER_FAILURE_POLICY=503
+```
+
+Set MCP env:
+
+```env
+MCP_PORT=<Railway assigned port>
+AGENT_BASE_URL=<agent-service Railway private URL, or public HTTPS URL if private DNS is unavailable>
+AGENT_SERVICE_TOKEN=<same high-entropy service token as agent-service>
+PARENT_PROFILE_STORE=redis
+PARENT_AUTH_SECRET=<high-entropy parent secret>
+PARENT_HISTORY_RETENTION_DAYS=30
+PARENT_HISTORY_MAX_EVENTS=200
+```
+
+Only expose the MCP service publicly for ChatGPT and the remote smoke. Keep agent-service private where Railway supports it; if a public agent URL is temporarily needed, `AGENT_SERVICE_TOKEN` and the secured startup posture still protect direct calls.
 
 ### Ngrok (optional)
 

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -15,6 +15,7 @@ export interface McpServerConfig {
 type McpServerEnv = Partial<
   Record<
     | 'AGENT_PORT'
+    | 'AGENT_BASE_URL'
     | 'AGENT_SERVICE_TOKEN'
     | 'FALLBACK_WIDGET'
     | 'KIDBOT_LOCAL_DEV'
@@ -51,6 +52,22 @@ const parsePositiveInteger = (name: string, value: string | undefined, fallback:
   return parsed;
 };
 
+const parseBaseUrl = (name: string, value: string | undefined): string | undefined => {
+  const trimmed = trimOptional(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('invalid protocol');
+    }
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    throw new Error(`${name} must be a valid http(s) URL.`);
+  }
+};
+
 const validateServiceToken = ({
   serviceAuthToken,
   fallbackMode,
@@ -78,6 +95,7 @@ const validateServiceToken = ({
 
 export const parseMcpServerConfig = (env: McpServerEnv = process.env): McpServerConfig => {
   const agentPort = parsePort('AGENT_PORT', env.AGENT_PORT, 4505);
+  const agentBaseUrl = parseBaseUrl('AGENT_BASE_URL', env.AGENT_BASE_URL) ?? `http://localhost:${agentPort}`;
   const mcpPort = parsePort('MCP_PORT', env.MCP_PORT, 3000);
   const fallbackMode = env.FALLBACK_WIDGET === '1';
   const localDevIntent = env.KIDBOT_LOCAL_DEV === '1';
@@ -113,7 +131,7 @@ export const parseMcpServerConfig = (env: McpServerEnv = process.env): McpServer
 
   return {
     agentPort,
-    agentBaseUrl: `http://localhost:${agentPort}`,
+    agentBaseUrl,
     mcpPort,
     fallbackMode,
     localDevIntent,

--- a/apps/mcp-server/test/parent-store.test.mjs
+++ b/apps/mcp-server/test/parent-store.test.mjs
@@ -20,6 +20,33 @@ test('parent profile config is disabled by default and needs no secret', () => {
 
   assert.equal(config.parentProfileStore, 'disabled');
   assert.equal(config.parentAuthSecret, undefined);
+  assert.equal(config.agentBaseUrl, 'http://localhost:4505');
+});
+
+test('agent base url overrides local agent port for split-service deploys', () => {
+  const config = parseMcpServerConfig({
+    AGENT_BASE_URL: 'https://kidbot-agent-service.railway.internal/',
+    AGENT_PORT: '4999',
+    AGENT_SERVICE_TOKEN: 'service-token-abcdefghijklmnopqrstuvwxyz0123456789',
+    FALLBACK_WIDGET: '0',
+    NODE_ENV: 'production',
+  });
+
+  assert.equal(config.agentPort, 4999);
+  assert.equal(config.agentBaseUrl, 'https://kidbot-agent-service.railway.internal');
+});
+
+test('agent base url rejects non-http values', () => {
+  assert.throws(
+    () =>
+      parseMcpServerConfig({
+        AGENT_BASE_URL: 'redis://kidbot-agent-service.internal',
+        AGENT_SERVICE_TOKEN: 'service-token-abcdefghijklmnopqrstuvwxyz0123456789',
+        FALLBACK_WIDGET: '0',
+        NODE_ENV: 'production',
+      }),
+    /AGENT_BASE_URL must be a valid http\(s\) URL/i,
+  );
 });
 
 test('redis parent profile storage requires a secret', () => {


### PR DESCRIPTION
## Summary
- add AGENT_BASE_URL support for MCP split-service production deploys
- document Railway service layout, build/start commands, and production env
- add config coverage for AGENT_BASE_URL override and validation

## Validation
- pnpm --filter @kidbot/mcp-server run build
- pnpm --filter @kidbot/agent-service run build
- pnpm run typecheck
- REDIS_URL=redis://localhost:6379 pnpm --filter @kidbot/mcp-server run test:parent-store
- pnpm run smoke:secured-posture
- REDIS_URL=redis://localhost:6379 pnpm run smoke:parent-store-redis
- pnpm run lint
- git diff --check

## Deployment note
- Created the GitHub `production` environment shell.
- Railway deploy and KIDBOT_REMOTE_MCP_URL secret are still blocked until a real Railway MCP URL and production secrets exist.
