### PR TITLE
Harden local verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The `dev` script runs the widget (Vite), MCP server, and agent service together.
 
 ### Verification
 
-- Authoritative recursive test run (packages with a `test` script): `pnpm -r --if-present run test -- --run`
+- Authoritative recursive test run (packages with a `test` script): `pnpm -r --if-present run test`
 - MCP compatibility smoke test (not included in recursive `test`): `pnpm --filter mcp-server run test:compat`
-- Root wrapper: `pnpm run test` (runs full recursive tests only when pnpm and workspace dependencies are detectable)
+- Root wrapper: `pnpm run test` (runs full recursive package tests when pnpm and workspace dependencies are detectable; otherwise falls back to smoke-only mode)
 - If the wrapper prints a smoke-only fallback warning, package Vitest suites were not executed.
 
 ### Environment

--- a/apps/agent-service/package.json
+++ b/apps/agent-service/package.json
@@ -7,7 +7,7 @@
     "dev": "cross-env NODE_ENV=development tsx watch src/index.ts",
     "start": "node --enable-source-maps dist/index.js",
     "build": "tsc -p tsconfig.json",
-    "test": "vitest --coverage",
+    "test": "vitest --run --coverage",
     "lint": "eslint src --max-warnings=0"
   },
   "dependencies": {

--- a/apps/web-widget/package.json
+++ b/apps/web-widget/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src --max-warnings=0",
-    "test": "vitest --run --environment jsdom"
+    "test": "cross-env NODE_ENV=test vitest --run --environment jsdom"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/scripts/run-test.mjs
+++ b/scripts/run-test.mjs
@@ -1,15 +1,55 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import path from 'node:path';
 
-const pnpmCommand = ['pnpm', 'pnpm.cmd'].find((command) => spawnSync(command, ['--version'], { stdio: 'ignore' }).status === 0);
+const resolvePathCommand = (name) => {
+  const pathValue = process.env.PATH ?? '';
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) {
+      continue;
+    }
+    const candidate = path.join(dir, name);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+const pnpmPs1 = resolvePathCommand('pnpm.ps1');
+const pnpmCandidates = [
+  { command: 'pnpm', args: [], label: 'pnpm', shell: false },
+  { command: 'pnpm.cmd', args: [], label: 'pnpm.cmd', shell: true },
+  ...(pnpmPs1
+    ? [
+        {
+          command: 'powershell.exe',
+          args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', pnpmPs1],
+          label: 'pnpm.ps1',
+          shell: false
+        }
+      ]
+    : [])
+];
+const pnpmCommand = pnpmCandidates.find(
+  (candidate) =>
+    spawnSync(candidate.command, [...candidate.args, '--version'], {
+      shell: candidate.shell,
+      stdio: 'ignore',
+      timeout: 5_000
+    }).status === 0
+);
 const hasNodeModules = ['node_modules', 'apps/agent-service/node_modules', 'apps/mcp-server/node_modules', 'apps/web-widget/node_modules']
   .some((dir) => existsSync(dir));
 const strictMode = process.env.STRICT_VERIFY === '1';
 
 if (pnpmCommand && hasNodeModules) {
-  console.log('🧪 Running full workspace tests via pnpm recursive scripts');
-  const result = spawnSync(pnpmCommand, ['-r', '--if-present', 'run', 'test', '--', '--run'], { stdio: 'inherit' });
+  console.log(`🧪 Running full workspace tests via ${pnpmCommand.label} recursive scripts`);
+  const result = spawnSync(pnpmCommand.command, [...pnpmCommand.args, '-r', '--if-present', 'run', 'test'], {
+    shell: pnpmCommand.shell,
+    stdio: 'inherit'
+  });
   process.exit(result.status ?? 0);
 }
 


### PR DESCRIPTION
## Summary

Harden local verification so Windows/PowerShell and production-like shells run the intended package test suites instead of falling back or hanging.

## Changes

- Force web-widget tests to run with `NODE_ENV=test`.
- Make agent-service tests non-watch by default.
- Update the root test wrapper to detect Windows pnpm shims and remove duplicate `--run` passthrough.
- Fix README verification commands to match the package scripts.

## Validation

- `pnpm run test`
- `$env:NODE_ENV='production'; pnpm --filter web-widget run test`
- `pnpm --filter mcp-server run test:compat`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
