### PR TITLE
Add voice playback boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ The remote smoke uses only the deployed MCP URL. It never reads, sends, or logs 
 
 GitHub Actions also includes the manual `Production Parent Store Smoke` workflow. Store `KIDBOT_REMOTE_MCP_URL` as a protected production environment secret before running it.
 
+### Voice Playback Boundary
+
+The widget currently uses browser `speechSynthesis` for local voice playback. Realtime STT/TTS should be integrated behind the widget voice playback boundary so the existing `voice_chat` tool contract and child-safety flow remain unchanged.
+
 ### Railway Production Deploy
 
 Railway is the first recommended production host for Kidbot because the repo currently runs long-lived Node/Express services plus Redis.

--- a/apps/web-widget/src/components/VoiceBar.playback.test.tsx
+++ b/apps/web-widget/src/components/VoiceBar.playback.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VoiceBar } from './VoiceBar.js';
+
+class MockSpeechSynthesisUtterance {
+  rate = 1;
+
+  constructor(public readonly text: string) {}
+}
+
+describe('VoiceBar speech playback', () => {
+  const callTool = vi.fn();
+  const cancel = vi.fn();
+  const speak = vi.fn();
+
+  const installSpeechPlayback = () => {
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        cancel,
+        speak,
+      },
+    });
+    Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+      configurable: true,
+      value: MockSpeechSynthesisUtterance,
+    });
+  };
+
+  beforeEach(() => {
+    callTool.mockReset();
+    cancel.mockReset();
+    speak.mockReset();
+    installSpeechPlayback();
+    (window as { openai?: unknown }).openai = {
+      callTool,
+      setWidgetState: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as { openai?: unknown }).openai;
+    delete (window as { speechSynthesis?: unknown }).speechSynthesis;
+    delete (window as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance;
+  });
+
+  it('speaks successful replies and replays them on request', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      persona: 'robot',
+      text: 'A happy moon fact.',
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(speak).toHaveBeenCalledTimes(1);
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(speak.mock.calls[0]?.[0]).toMatchObject({
+      rate: 1.05,
+      text: 'A happy moon fact.',
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Replay' }));
+
+    await waitFor(() => {
+      expect(speak).toHaveBeenCalledTimes(2);
+    });
+    expect(cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not speak blocked replies', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: true,
+      message: 'Kidbot paused this request.',
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Kidbot paused this request.').length).toBeGreaterThan(0);
+    });
+    expect(speak).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('does not speak degraded replies', async () => {
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      degraded: true,
+      message:
+        'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          'Kidbot is having trouble reaching its idea engine right now. Please try again in a moment.',
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(speak).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('renders successful replies when browser speech playback is unavailable', async () => {
+    delete (window as { speechSynthesis?: unknown }).speechSynthesis;
+    delete (window as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance;
+    callTool.mockResolvedValueOnce({
+      blocked: false,
+      persona: 'robot',
+      text: 'Space fact ready!',
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await screen.findByText('Space fact ready!');
+    expect(screen.queryByRole('button', { name: 'Replay' })).not.toBeNull();
+    expect(speak).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -7,6 +7,7 @@ import {
   unavailableMessageFromError,
 } from '../utils/degradation.js';
 import { defaultSessionContext, type SessionContext } from '../utils/sessionContext.js';
+import { speakText } from '../utils/voicePlayback.js';
 
 type Persona = 'robot' | 'fairy' | 'explorer';
 
@@ -24,16 +25,6 @@ const personas: Array<{ key: Persona; label: string }> = [
   { key: 'fairy', label: 'Fairy Friend' },
   { key: 'explorer', label: 'Explorer Pal' },
 ];
-
-const speakText = (text: string) => {
-  if (typeof window === 'undefined' || typeof window.speechSynthesis === 'undefined') {
-    return;
-  }
-  const utterance = new SpeechSynthesisUtterance(text);
-  utterance.rate = 1.05;
-  window.speechSynthesis.cancel();
-  window.speechSynthesis.speak(utterance);
-};
 
 interface VoiceBarProps {
   sessionContext?: SessionContext;

--- a/apps/web-widget/src/utils/voicePlayback.ts
+++ b/apps/web-widget/src/utils/voicePlayback.ts
@@ -1,0 +1,21 @@
+export const isSpeechPlaybackAvailable = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.speechSynthesis !== 'undefined' &&
+  typeof window.SpeechSynthesisUtterance !== 'undefined';
+
+export const stopSpeaking = (): void => {
+  if (typeof window === 'undefined' || typeof window.speechSynthesis === 'undefined') {
+    return;
+  }
+  window.speechSynthesis.cancel();
+};
+
+export const speakText = (text: string): void => {
+  if (!text.trim() || !isSpeechPlaybackAvailable()) {
+    return;
+  }
+  const utterance = new window.SpeechSynthesisUtterance(text);
+  utterance.rate = 1.05;
+  stopSpeaking();
+  window.speechSynthesis.speak(utterance);
+};


### PR DESCRIPTION
## Summary

Add a small widget voice playback boundary around browser speech synthesis so future Realtime voice work can plug in without changing the `voice_chat` tool contract.

## Changes

- Move browser `speechSynthesis` handling into a typed `voicePlayback` utility.
- Refactor `VoiceBar` to use the utility while keeping current UI and tool payload behavior unchanged.
- Add playback-focused tests for success, replay, blocked/degraded responses, and missing browser speech support.
- Document the current browser TTS boundary and future Realtime STT/TTS integration point.

## Validation

- `pnpm run test`
- `$env:NODE_ENV='production'; pnpm --filter web-widget run test`
- `pnpm --filter mcp-server run test:compat`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
