### PR TITLE
Add voice input capture foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ GitHub Actions also includes the manual `Production Parent Store Smoke` workflow
 ### Voice Playback Boundary
 
 The widget currently uses browser `speechSynthesis` for local voice playback. Realtime STT/TTS should be integrated behind the widget voice playback boundary so the existing `voice_chat` tool contract and child-safety flow remain unchanged.
+Voice input currently uses browser speech recognition where available and writes captured text into the existing prompt box. Future Realtime STT/TTS should replace the internals behind the voice capture/playback utilities, not the `voice_chat` contract.
 
 ### Railway Production Deploy
 

--- a/apps/web-widget/src/components/VoiceBar.capture.test.tsx
+++ b/apps/web-widget/src/components/VoiceBar.capture.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VoiceBar } from './VoiceBar.js';
+
+interface MockSpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly 0: {
+    readonly transcript: string;
+  };
+}
+
+interface MockSpeechRecognitionResultEvent {
+  readonly results: ArrayLike<MockSpeechRecognitionResult>;
+}
+
+class MockSpeechRecognition {
+  static instances: MockSpeechRecognition[] = [];
+
+  continuous = true;
+  interimResults = true;
+  lang = '';
+  onend: (() => void) | null = null;
+  onerror: ((event: { error?: string }) => void) | null = null;
+  onresult: ((event: MockSpeechRecognitionResultEvent) => void) | null = null;
+  onstart: (() => void) | null = null;
+  start = vi.fn(() => this.onstart?.());
+  stop = vi.fn(() => this.onend?.());
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
+}
+
+const finalTranscriptEvent = (transcript: string): MockSpeechRecognitionResultEvent => ({
+  results: {
+    0: {
+      0: { transcript },
+      isFinal: true,
+    },
+    length: 1,
+  },
+});
+
+describe('VoiceBar voice capture', () => {
+  const callTool = vi.fn();
+
+  const installVoiceCapture = () => {
+    Object.defineProperty(window, 'SpeechRecognition', {
+      configurable: true,
+      value: MockSpeechRecognition,
+    });
+  };
+
+  beforeEach(() => {
+    callTool.mockReset();
+    MockSpeechRecognition.instances = [];
+    (window as { openai?: unknown }).openai = {
+      callTool,
+      setWidgetState: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as { openai?: unknown }).openai;
+    delete window.SpeechRecognition;
+    delete window.webkitSpeechRecognition;
+  });
+
+  it('shows disabled unavailable control when speech recognition is unsupported', () => {
+    render(<VoiceBar />);
+
+    expect(
+      screen.getByRole<HTMLButtonElement>('button', { name: 'Voice Input Unavailable' }).disabled,
+    ).toBe(true);
+  });
+
+  it('starts supported voice capture and shows the stop control', async () => {
+    installVoiceCapture();
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+
+    const recognition = MockSpeechRecognition.instances[0];
+    expect(recognition?.continuous).toBe(false);
+    expect(recognition?.interimResults).toBe(false);
+    expect(recognition?.lang).toBe('en-US');
+    expect(recognition?.start).toHaveBeenCalledTimes(1);
+    await screen.findByRole('button', { name: 'Stop Voice Input' });
+  });
+
+  it('writes captured transcript into the textarea without submitting', async () => {
+    installVoiceCapture();
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+    MockSpeechRecognition.instances[0]?.onresult?.(finalTranscriptEvent('Tell me about Saturn'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText<HTMLTextAreaElement>('Ask a question or share a topic').value,
+      ).toBe('Tell me about Saturn');
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('stops supported voice capture and returns to idle', async () => {
+    installVoiceCapture();
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+    const recognition = MockSpeechRecognition.instances[0];
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop Voice Input' }));
+
+    expect(recognition?.stop).toHaveBeenCalledTimes(1);
+    await screen.findByRole('button', { name: 'Start Voice Input' });
+  });
+
+  it('stops active capture on unmount', async () => {
+    installVoiceCapture();
+
+    const { unmount } = render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+    await screen.findByRole('button', { name: 'Stop Voice Input' });
+    const recognition = MockSpeechRecognition.instances[0];
+
+    unmount();
+
+    expect(recognition?.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { LiveRegion } from './LiveRegion.js';
 import { buildAnnouncementState } from '../utils/announcementState.js';
 import {
@@ -7,9 +7,15 @@ import {
   unavailableMessageFromError,
 } from '../utils/degradation.js';
 import { defaultSessionContext, type SessionContext } from '../utils/sessionContext.js';
+import {
+  createVoiceCapture,
+  isVoiceCaptureAvailable,
+  type VoiceCaptureSession,
+} from '../utils/voiceCapture.js';
 import { speakText } from '../utils/voicePlayback.js';
 
 type Persona = 'robot' | 'fairy' | 'explorer';
+type CaptureState = 'idle' | 'listening' | 'unsupported';
 
 interface VoiceResult {
   blocked: boolean;
@@ -33,10 +39,14 @@ interface VoiceBarProps {
 export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarProps) => {
   const [persona, setPersona] = useState<Persona>('robot');
   const [text, setText] = useState('Tell me a cheerful space fact!');
+  const [captureState, setCaptureState] = useState<CaptureState>(() =>
+    isVoiceCaptureAvailable() ? 'idle' : 'unsupported',
+  );
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<VoiceResult | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [unavailable, setUnavailable] = useState<string | undefined>();
+  const captureSessionRef = useRef<VoiceCaptureSession | undefined>();
   const blockedMessage = response?.blocked
     ? (response.message ?? 'Kidbot paused this request.')
     : undefined;
@@ -47,6 +57,49 @@ export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarPro
     urgentMessage: unavailable ?? blockedMessage,
     readyMessage: response?.text ? `${response.persona ?? 'Kidbot'} reply ready.` : '',
   });
+
+  useEffect(
+    () => () => {
+      captureSessionRef.current?.stop();
+    },
+    [],
+  );
+
+  const handleVoiceInput = () => {
+    if (captureState === 'unsupported') {
+      return;
+    }
+    if (captureState === 'listening') {
+      captureSessionRef.current?.stop();
+      setCaptureState('idle');
+      return;
+    }
+
+    const session = createVoiceCapture({
+      onEnd: () => setCaptureState('idle'),
+      onError: (message) => {
+        setError(message);
+        setCaptureState('idle');
+      },
+      onStart: () => setCaptureState('listening'),
+      onText: (transcript) => setText(transcript),
+    });
+    if (!session) {
+      setCaptureState('unsupported');
+      return;
+    }
+
+    setError(undefined);
+    captureSessionRef.current = session;
+    session.start();
+  };
+
+  const voiceInputLabel =
+    captureState === 'unsupported'
+      ? 'Voice Input Unavailable'
+      : captureState === 'listening'
+        ? 'Stop Voice Input'
+        : 'Start Voice Input';
 
   const handleSpeak = async () => {
     if (!text.trim()) {
@@ -114,6 +167,13 @@ export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarPro
         placeholder="Ask a question or share a topic"
         rows={3}
       />
+      <button
+        type="button"
+        onClick={handleVoiceInput}
+        disabled={captureState === 'unsupported'}
+      >
+        {voiceInputLabel}
+      </button>
       <button type="button" onClick={handleSpeak} disabled={loading}>
         {loading ? 'Thinking...' : 'Speak'}
       </button>

--- a/apps/web-widget/src/utils/voiceCapture.ts
+++ b/apps/web-widget/src/utils/voiceCapture.ts
@@ -1,0 +1,90 @@
+interface SpeechRecognitionResultLike {
+  readonly isFinal: boolean;
+  readonly 0: {
+    readonly transcript: string;
+  };
+}
+
+interface SpeechRecognitionEventLike {
+  readonly results: ArrayLike<SpeechRecognitionResultLike>;
+}
+
+interface SpeechRecognitionErrorEventLike {
+  readonly error?: string;
+}
+
+interface BrowserSpeechRecognition {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onend: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onstart: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+}
+
+type SpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+export interface VoiceCaptureOptions {
+  onEnd?: () => void;
+  onError?: (message: string) => void;
+  onStart?: () => void;
+  onText?: (text: string) => void;
+}
+
+export interface VoiceCaptureSession {
+  start: () => void;
+  stop: () => void;
+}
+
+const getSpeechRecognitionConstructor = (): SpeechRecognitionConstructor | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition;
+};
+
+export const isVoiceCaptureAvailable = (): boolean =>
+  typeof getSpeechRecognitionConstructor() !== 'undefined';
+
+export const createVoiceCapture = (
+  options: VoiceCaptureOptions,
+): VoiceCaptureSession | undefined => {
+  const SpeechRecognition = getSpeechRecognitionConstructor();
+  if (!SpeechRecognition) {
+    return undefined;
+  }
+
+  const recognition = new SpeechRecognition();
+  recognition.continuous = false;
+  recognition.interimResults = false;
+  recognition.lang = 'en-US';
+  recognition.onstart = () => options.onStart?.();
+  recognition.onend = () => options.onEnd?.();
+  recognition.onerror = (event) => {
+    options.onError?.(event.error ?? 'Voice input stopped.');
+  };
+  recognition.onresult = (event) => {
+    for (let index = 0; index < event.results.length; index += 1) {
+      const result = event.results[index];
+      const transcript = result?.[0]?.transcript?.trim();
+      if (result?.isFinal && transcript) {
+        options.onText?.(transcript);
+      }
+    }
+  };
+
+  return {
+    start: () => recognition.start(),
+    stop: () => recognition.stop(),
+  };
+};


### PR DESCRIPTION
## Summary
- add a browser speech recognition boundary for the web widget
- wire VoiceBar to capture final transcripts into the existing prompt box without auto-submit
- document that browser capture/playback are local boundaries for future Realtime STT/TTS

## Validation
- pnpm run test
- $env:NODE_ENV='production'; pnpm --filter web-widget run test
- pnpm --filter mcp-server run test:compat
- pnpm run typecheck
- pnpm run lint