### PR TITLE
Harden voice capture status

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ GitHub Actions also includes the manual `Production Parent Store Smoke` workflow
 
 The widget currently uses browser `speechSynthesis` for local voice playback. Realtime STT/TTS should be integrated behind the widget voice playback boundary so the existing `voice_chat` tool contract and child-safety flow remain unchanged.
 Voice input currently uses browser speech recognition where available and writes captured text into the existing prompt box. Future Realtime STT/TTS should replace the internals behind the voice capture/playback utilities, not the `voice_chat` contract.
+Browser speech recognition may ask for microphone permission; unsupported browsers continue to use typed input.
 
 ### Railway Production Deploy
 

--- a/apps/web-widget/src/components/VoiceBar.capture.test.tsx
+++ b/apps/web-widget/src/components/VoiceBar.capture.test.tsx
@@ -41,6 +41,11 @@ const finalTranscriptEvent = (transcript: string): MockSpeechRecognitionResultEv
   },
 });
 
+const permissionBlockedMessage =
+  'Microphone access is blocked. You can still type your question.';
+const retryVoiceInputMessage =
+  'Voice input stopped. You can try again or type your question.';
+
 describe('VoiceBar voice capture', () => {
   const callTool = vi.fn();
 
@@ -88,6 +93,7 @@ describe('VoiceBar voice capture', () => {
     expect(recognition?.lang).toBe('en-US');
     expect(recognition?.start).toHaveBeenCalledTimes(1);
     await screen.findByRole('button', { name: 'Stop Voice Input' });
+    expect(screen.getAllByText('Listening...').length).toBeGreaterThan(0);
   });
 
   it('writes captured transcript into the textarea without submitting', async () => {
@@ -118,6 +124,55 @@ describe('VoiceBar voice capture', () => {
 
     expect(recognition?.stop).toHaveBeenCalledTimes(1);
     await screen.findByRole('button', { name: 'Start Voice Input' });
+  });
+
+  it('shows a microphone-blocked message and returns to idle after permission denial', async () => {
+    installVoiceCapture();
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+    MockSpeechRecognition.instances[0]?.onerror?.({ error: 'not-allowed' });
+
+    expect((await screen.findAllByText(permissionBlockedMessage)).length).toBeGreaterThan(0);
+    await screen.findByRole('button', { name: 'Start Voice Input' });
+  });
+
+  it('shows a retry-safe message and returns to idle when speech is not captured', async () => {
+    installVoiceCapture();
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+    MockSpeechRecognition.instances[0]?.onerror?.({ error: 'no-speech' });
+
+    expect((await screen.findAllByText(retryVoiceInputMessage)).length).toBeGreaterThan(0);
+    await screen.findByRole('button', { name: 'Start Voice Input' });
+  });
+
+  it('keeps typed input and Speak working after a capture error', async () => {
+    installVoiceCapture();
+    callTool.mockResolvedValue({
+      blocked: false,
+      persona: 'robot',
+      text: 'Beep! Jupiter is the biggest planet.',
+    });
+
+    render(<VoiceBar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Voice Input' }));
+    MockSpeechRecognition.instances[0]?.onerror?.({ error: 'aborted' });
+    fireEvent.change(screen.getByPlaceholderText('Ask a question or share a topic'), {
+      target: { value: 'Tell me about Jupiter' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Speak' }));
+
+    await waitFor(() => {
+      expect(callTool).toHaveBeenCalledWith(
+        'voice_chat',
+        expect.objectContaining({ text: 'Tell me about Jupiter' }),
+      );
+    });
   });
 
   it('stops active capture on unmount', async () => {

--- a/apps/web-widget/src/components/VoiceBar.tsx
+++ b/apps/web-widget/src/components/VoiceBar.tsx
@@ -17,6 +17,15 @@ import { speakText } from '../utils/voicePlayback.js';
 type Persona = 'robot' | 'fairy' | 'explorer';
 type CaptureState = 'idle' | 'listening' | 'unsupported';
 
+const permissionBlockedMessage =
+  'Microphone access is blocked. You can still type your question.';
+const retryVoiceInputMessage =
+  'Voice input stopped. You can try again or type your question.';
+const permissionErrorPattern = /not-allowed|permission|service-not-allowed/i;
+
+const voiceCaptureErrorMessage = (message: string): string =>
+  permissionErrorPattern.test(message) ? permissionBlockedMessage : retryVoiceInputMessage;
+
 interface VoiceResult {
   blocked: boolean;
   degraded?: boolean;
@@ -45,6 +54,7 @@ export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarPro
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<VoiceResult | undefined>();
   const [error, setError] = useState<string | undefined>();
+  const [captureMessage, setCaptureMessage] = useState<string | undefined>();
   const [unavailable, setUnavailable] = useState<string | undefined>();
   const captureSessionRef = useRef<VoiceCaptureSession | undefined>();
   const blockedMessage = response?.blocked
@@ -55,7 +65,12 @@ export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarPro
     loadingMessage: 'Kidbot is thinking.',
     errorMessage: error,
     urgentMessage: unavailable ?? blockedMessage,
-    readyMessage: response?.text ? `${response.persona ?? 'Kidbot'} reply ready.` : '',
+    readyMessage:
+      captureState === 'listening'
+        ? 'Listening...'
+        : response?.text
+          ? `${response.persona ?? 'Kidbot'} reply ready.`
+          : '',
   });
 
   useEffect(
@@ -71,27 +86,47 @@ export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarPro
     }
     if (captureState === 'listening') {
       captureSessionRef.current?.stop();
+      captureSessionRef.current = undefined;
       setCaptureState('idle');
       return;
     }
 
     const session = createVoiceCapture({
-      onEnd: () => setCaptureState('idle'),
-      onError: (message) => {
-        setError(message);
+      onEnd: () => {
+        captureSessionRef.current = undefined;
         setCaptureState('idle');
       },
-      onStart: () => setCaptureState('listening'),
-      onText: (transcript) => setText(transcript),
+      onError: (message) => {
+        setError(voiceCaptureErrorMessage(message));
+        setCaptureMessage(undefined);
+        setCaptureState('idle');
+      },
+      onStart: () => {
+        setCaptureMessage('Listening...');
+        setCaptureState('listening');
+      },
+      onText: (transcript) => {
+        setText(transcript);
+        setCaptureMessage(undefined);
+      },
     });
     if (!session) {
       setCaptureState('unsupported');
+      setCaptureMessage(undefined);
       return;
     }
 
     setError(undefined);
+    setCaptureMessage(undefined);
     captureSessionRef.current = session;
-    session.start();
+    try {
+      session.start();
+    } catch (err) {
+      captureSessionRef.current = undefined;
+      setCaptureState('idle');
+      setCaptureMessage(undefined);
+      setError(voiceCaptureErrorMessage(errorMessage(err)));
+    }
   };
 
   const voiceInputLabel =
@@ -177,6 +212,7 @@ export const VoiceBar = ({ sessionContext = defaultSessionContext }: VoiceBarPro
       <button type="button" onClick={handleSpeak} disabled={loading}>
         {loading ? 'Thinking...' : 'Speak'}
       </button>
+      {captureMessage && <p className="capture-status">{captureMessage}</p>}
       {error && <p className="error">{error}</p>}
       {unavailable && <p className="degraded">{unavailable}</p>}
       {response && (

--- a/apps/web-widget/src/styles.css
+++ b/apps/web-widget/src/styles.css
@@ -183,6 +183,12 @@ textarea {
   font-weight: 600;
 }
 
+.capture-status {
+  color: #166534;
+  font-weight: 600;
+  margin: 0;
+}
+
 .blocked {
   color: #ea580c;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add visible listening status for browser voice input
- translate speech recognition permission and retry errors into kid-safe messages
- keep typed input and explicit Speak submission working after capture errors
- document microphone permission behavior for browser speech recognition

## Validation
- pnpm --filter web-widget run test
- pnpm run test
- $env:NODE_ENV='production'; pnpm --filter web-widget run test
- pnpm --filter mcp-server run test:compat
- pnpm run typecheck
- pnpm run lint